### PR TITLE
Makefile: fix build for arm7neonhf platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,26 @@ ifneq (,$(findstring unix,$(platform)))
       ASFLAGS = -f elf -d ELF_TYPE
    endif
 
+   ifneq (,$(findstring armv,$(platform)))
+      CPUFLAGS += -DARM -marm
+      ifneq (,$(findstring cortexa8,$(platform)))
+         CPUFLAGS += -mcpu=cortex-a8
+      else ifneq (,$(findstring cortexa9,$(platform)))
+         CPUFLAGS += -mcpu=cortex-a9
+      else
+         CPUFLAGS += -mcpu=cortex-a7
+      endif
+      ifneq (,$(findstring neon,$(platform)))
+          CPUFLAGS += -mfpu=neon
+          HAVE_NEON = 1
+      endif
+      ifneq (,$(findstring softfloat,$(platform)))
+          CPUFLAGS += -mfloat-abi=softfp
+      else ifneq (,$(findstring hardfloat,$(platform)))
+          CPUFLAGS += -mfloat-abi=hard
+      endif
+   endif
+
 # Raspberry Pi
 else ifneq (,$(findstring rpi,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
This platform is used by the libretro-super buildbot.

Tested using the following make invocation:

    make platform=unix-armv7-hardfloat-neon -j4 WITH_DYNAREC=arm

With this PR, the following line can be now added to the recipes in `recipes/linux/cores-linux-arm7neonhf`  of the libretro-super repository:

    mupen64plus_next libretro-mupen64plus_next https://github.com/libretro/mupen64plus-libretro-nx.git mupen_next YES GENERIC_GL Makefile . WITH_DYNAREC=arm

Note: I only tested that the build succeeds, but haven't tested the actual core in retroarch. However the build is very similar to the old mupen64plus core, should be fine. Nevertheless this PR is a good starting point to start receiving more feedback using the buildbot binaries.