### PR TITLE
Makefile: add missing CFLAGS for C standard selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ else ifeq ($(platform), libnx)
    CPUOPTS := -g -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd
    PLATCFLAGS = -O3 -ffast-math -funsafe-math-optimizations -fPIE -I$(PORTLIBS)/include/ -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec -specs=$(LIBNX)/switch.specs
    PLATCFLAGS += $(INCLUDE) -D__SWITCH__=1 -DSWITCH -DHAVE_LIBNX -D_GLIBCXX_USE_C99_MATH_TR1 -D_LDBL_EQ_DBL -funroll-loops
-   CXXFLAGS += -fno-rtti -std=gnu++11
+   CXXFLAGS += -fno-rtti
    COREFLAGS += -DOS_LINUX
    GLES = 0
    WITH_DYNAREC = aarch64
@@ -341,9 +341,9 @@ endif
    CXXFLAGS += -fvisibility-inlines-hidden
 endif
 
-ifneq ($(platform), libnx)
-CXXFLAGS += -std=c++11
-endif
+# set C/C++ standard to use
+CFLAGS += -std=gnu11
+CXXFLAGS += -std=gnu++11
 
 ifeq ($(PIC), 1)
    fpic = -fPIC


### PR DESCRIPTION
Some feedback from RetroPie users already arrived!
A user discovered that there is a missing flag for older compilers, i.e. in Raspbian Jessie.

The `libnx` part is not strictly necessary because on newer compilers it defaults to `gnu11` already, nevertheless I explicitly added it for consistency.

---

In older versions of GCC, the `gnu11` standard is not selected by default.

Setting the standard to `gnu11` fixes these compilation errors:

    mupen64plus-core/src/device/r4300/new_dynarec/arm/assem_arm.c:4300:9: error:
    ‘for’ loop initial declarations are only allowed in C99 or C11 mode
         for(int hr=0;hr<HOST_REGS;hr++) {
         ^
    mupen64plus-core/src/device/r4300/new_dynarec/arm/assem_arm.c:4300:9: note:
    use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
