### PR TITLE
Add configurable max texture cache size

### DIFF
--- a/GLideN64/src/Textures.cpp
+++ b/GLideN64/src/Textures.cpp
@@ -18,6 +18,8 @@
 #include "GLideNHQ/Ext_TxFilter.h"
 #include "TextureFilterHandler.h"
 
+#include "../../../custom/GLideN64/GLideN64_libretro.h"
+
 #ifdef HAVE_LIBNX
 #include <switch.h>
 #endif
@@ -526,14 +528,7 @@ void TextureCache::destroy()
 
 void TextureCache::_checkCacheSize()
 {
-#ifdef VC
-	const size_t maxCacheSize = 15000;
-#elif defined(HAVE_LIBNX)
-	const size_t maxCacheSize = 4000;
-#else
-	const size_t maxCacheSize = 16384;
-#endif
-	if (m_textures.size() >= maxCacheSize) {
+	if (m_textures.size() >= MaxTxCacheSize) {
 		CachedTexture& clsTex = m_textures.back();
 		m_cachedBytes -= clsTex.textureBytes;
 		glDeleteTextures(1, &clsTex.glName);

--- a/custom/GLideN64/GLideN64_libretro.h
+++ b/custom/GLideN64/GLideN64_libretro.h
@@ -55,6 +55,7 @@ extern uint32_t enableLegacyBlending;
 extern uint32_t EnableCopyColorToRDRAM;
 extern uint32_t EnableCopyDepthToRDRAM;
 extern uint32_t AspectRatio;
+extern uint32_t MaxTxCacheSize;
 extern uint32_t txFilterMode;
 extern uint32_t txEnhancementMode;
 extern uint32_t txHiresEnable;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -97,6 +97,7 @@ uint32_t enableLegacyBlending = 0;
 uint32_t EnableCopyColorToRDRAM = 0;
 uint32_t EnableCopyDepthToRDRAM = 0;
 uint32_t AspectRatio = 0;
+uint32_t MaxTxCacheSize = 0;
 uint32_t txFilterMode = 0;
 uint32_t txEnhancementMode = 0;
 uint32_t txHiresEnable = 0;
@@ -214,6 +215,14 @@ static void setup_variables(void)
             "Cache GPU Shaders; True|False" },
         { CORE_NAME "-CropMode",
             "Crop Mode; Auto|Off" },
+        { CORE_NAME "-MaxTxCacheSize",
+#if defined(VC)
+            "Max texture cache size; 1500|8000|4000" },
+#elif defined(HAVE_LIBNX)
+            "Max texture cache size; 4000|1500|8000" },
+#else
+            "Max texture cache size; 8000|4000|1500" },
+#endif
         { CORE_NAME "-txFilterMode",
             "Texture filter; None|Smooth filtering 1|Smooth filtering 2|Smooth filtering 3|Smooth filtering 4|Sharp filtering 1|Sharp filtering 2" },
         { CORE_NAME "-txEnhancementMode",
@@ -699,6 +708,13 @@ void update_variables()
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
     {
         txHiresFullAlphaChannel = !strcmp(var.value, "False") ? 0 : 1;
+    }
+
+    var.key = CORE_NAME "-MaxTxCacheSize";
+    var.value = NULL;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+    {
+        MaxTxCacheSize = atoi(var.value);
     }
 
     var.key = CORE_NAME "-EnableLegacyBlending";


### PR DESCRIPTION
Set default to `1500` for VideCore, `4000` for LibNX and `8000` for others.

Values backported from upstream:
https://github.com/gonetz/GLideN64/blob/master/src/Textures.h#L103-L107

Users can select any max cache size they require for their devices without re-compiling.
Fixes #28 
