### PR TITLE
Makefile: added devices for Amlogic & Rockchip platforms

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/GLFunctions.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/GLFunctions.cpp
@@ -12,7 +12,7 @@
 #define glGetProcAddress wglGetProcAddress
 #define GL_GET_PROC_ADR(proc_type, proc_name) ptr##proc_name = (proc_type) glGetProcAddress("gl"#proc_name)
 
-#elif defined(VERO4K) || defined(ODROID) || defined(VC) || defined(AMLOGIC)
+#elif defined(VERO4K) || defined(ODROID) || defined(VC) || defined(USE_GENERIC_GLESV2)
 
 #include <dlfcn.h>
 #define GL_GET_PROC_ADR(proc_type, proc_name) ptr##proc_name = (proc_type) dlsym(gles2so, "gl"#proc_name);
@@ -210,7 +210,7 @@ extern "C" void initGLFunctions()
 	void *gles2so = dlopen("/usr/lib/arm-linux-gnueabihf/libGLESv2.so", RTLD_NOW);
 #elif defined(VERO4K)
        void *gles2so = dlopen("/opt/vero3/lib/libGLESv2.so", RTLD_NOW);
-#elif defined(AMLOGIC)
+#elif defined(USE_GENERIC_GLESV2)
        void *gles2so = dlopen("/usr/lib/libGLESv2.so", RTLD_NOW);
 #endif
 

--- a/GLideN64/src/Graphics/OpenGLContext/GLFunctions.h
+++ b/GLideN64/src/Graphics/OpenGLContext/GLFunctions.h
@@ -7,13 +7,9 @@
 #include <winlnxdefs.h>
 #endif
 
-#ifdef UNDEF_GL_GLEXT_PROTOTYPES
-// Issues on Raspberry since GL2.h defines it and causes
-// Macro shenanigans
 #ifdef GL_GLEXT_PROTOTYPES
 #undef GL_GLEXT_PROTOTYPES
 #endif // GL_GLEXT_PROTOTYPES
-#endif // UNDEF_GL_GLEXT_PROTOTYPES
 
 #ifdef EGL
 #include <GL/glcorearb.h>


### PR DESCRIPTION
The purpose of this PR is to add platforms for Amlogic & Rockchip while also build the core for specific devices with different ARM cores (A53/A17/A72/A73) & OpenGL ES 2.0 or 3.0 support. The Amlogic platform names where derived from the SoC naming scheme used by [meson-linux](http://linux-meson.com/doku.php#supported_wip_soc_families) and LibreELEC.

- Amlogic S905/S905X/S912 (GX) / S905X2 (G12A) & S922X/A311D (G12B)
- Rockchip RK3288/RK3328/RK3399
- updated `GLFunctions.cpp` to define `-DUSE_GENERIC_GLESV2` instead `-DAMLOGIC` because on most platforms with `libGLESv2.so` support there should be a lib in `/usr/lib/...` or a symlinkt to the vendor blob like `libmali.so` which can be used for Mali GPUs.
- removed `UNDEF_GL_GLEXT_PROTOTYPES` from `GLFunctions.h`

@shantigilbert have a look at this and test if this works fine for your S922X too?
@Ntemis can you check if it builds fine for RK3288?

Builds fine for all platforms & was tested on a RockPro64.

I was wondering if we could change this [elif](https://github.com/libretro/mupen64plus-libretro-nx/pull/74/files#diff-2e18049090f9b3589548e63b7f310e21R213) to else to always fall back on `/usr/lib/libGLESv2.so` if nothing else is defined & OpenGL ES should be used.