### PR TITLE
Fix Raspberry Pi 4 build configuration

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
@@ -54,8 +54,8 @@ bool Utils::isEGLExtensionSupported(const char * extension)
 	EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 	const char* extensions = eglQueryString(display, EGL_EXTENSIONS);
 	if (extensions == nullptr) {
-		EGLDisplay platformDisplay = eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, display, nullptr);
-		extensions = eglQueryString(platformDisplay, EGL_EXTENSIONS);
+		// FIXME: KMS/DRM requires EGL_PLATFORM_GBM_KHR and libgbm, see mupen64plus-libretro-nx#82
+		return true;
 	}
 
 	const char* start = extensions;

--- a/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
@@ -51,10 +51,15 @@ bool Utils::isEGLExtensionSupported(const char * extension)
 	if (where || *extension == '\0')
 		return false;
 
-	const char* extensions = eglQueryString(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_EXTENSIONS);
+	EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+	const char* extensions = eglQueryString(display, EGL_EXTENSIONS);
+	if (extensions == nullptr) {
+		EGLDisplay platformDisplay = eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, display, NULL);
+		extensions = eglQueryString(platformDisplay, EGL_EXTENSIONS);
+	}
 
 	const char* start = extensions;
-	while (start) {
+	for (;;) {
 		where = strstr(start, extension);
 		if (where == nullptr)
 			break;

--- a/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
@@ -51,8 +51,7 @@ bool Utils::isEGLExtensionSupported(const char * extension)
 	if (where || *extension == '\0')
 		return false;
 
-	EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-	const char* extensions = eglQueryString(display, EGL_EXTENSIONS);
+	const char* extensions = eglQueryString(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_EXTENSIONS);
 	if (extensions == nullptr) {
 		// FIXME: KMS/DRM requires EGL_PLATFORM_GBM_KHR and libgbm, see mupen64plus-libretro-nx#82
 		return true;

--- a/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
@@ -54,7 +54,7 @@ bool Utils::isEGLExtensionSupported(const char * extension)
 	const char* extensions = eglQueryString(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_EXTENSIONS);
 
 	const char* start = extensions;
-	for (;;) {
+	while (start) {
 		where = strstr(start, extension);
 		if (where == nullptr)
 			break;

--- a/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
@@ -54,7 +54,7 @@ bool Utils::isEGLExtensionSupported(const char * extension)
 	EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 	const char* extensions = eglQueryString(display, EGL_EXTENSIONS);
 	if (extensions == nullptr) {
-		EGLDisplay platformDisplay = eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, display, NULL);
+		EGLDisplay platformDisplay = eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, display, nullptr);
 		extensions = eglQueryString(platformDisplay, EGL_EXTENSIONS);
 	}
 

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,11 @@ ifneq (,$(findstring unix,$(platform)))
 else ifneq (,$(findstring rpi,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined -ldl
-   GLES = 1
+   ifeq ($(FORCE_GLES3),1)
+      GLES3 = 1
+   else
+      GLES = 1
+   endif
    ifneq (,$(findstring mesa,$(platform)))
       MESA = 1
    endif

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,9 @@ else ifneq (,$(findstring rpi,$(platform)))
    else ifneq (,$(findstring rpi3,$(platform)))
       CPUFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
       HAVE_NEON = 1
+   else ifneq (,$(findstring rpi4,$(platform)))
+      CPUFLAGS += -march=armv8-a+crc -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard
+      HAVE_NEON = 1
    endif
    COREFLAGS += -DOS_LINUX
    ASFLAGS = -f elf -d ELF_TYPE

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,12 @@ else ifneq (,$(findstring rpi,$(platform)))
    LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined -ldl
    GLES = 1
    ifneq (,$(findstring mesa,$(platform)))
+      MESA = 1
+   endif
+   ifneq (,$(findstring rpi4,$(platform)))
+      MESA = 1
+   endif
+   ifeq ($(MESA), 1)
       GL_LIB := -lGLESv2
    else
       LLE = 0


### PR DESCRIPTION
This branch cherry-picks ematysek's last commit from the (recently locked) [mupen64plus-libretro repo](https://github.com/libretro/mupen64plus-libretro).

I then fixed it so things just work as expected on Buster with:

    make platform=rpi4 -j4

This will link with Mesa GLES because the legacy brcmGLES driver is not functional on a Pi 4. Also fixed a null pointer crash on launch which may be specific to the version of Mesa used on Buster.