### PR TITLE
Fix segfault in EGL extension query for certain devices

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
@@ -57,7 +57,7 @@ DisplayWindow & DisplayWindow::get()
 
 void DisplayWindowMupen64plus::_setAttributes()
 {
-	LOG(LOG_VERBOSE, "[gles2GlideN64]: _setAttributes");
+	LOG(LOG_VERBOSE, "[GlideN64]: _setAttributes");
 }
 
 bool DisplayWindowMupen64plus::_start()
@@ -71,10 +71,12 @@ bool DisplayWindowMupen64plus::_start()
 	m_screenHeight = get_retro_screen_height();
 	_getDisplaySize();
 	_setBufferSize();
-	
-	LOG(LOG_VERBOSE, "[gles2GlideN64]: Create setting videomode %dx%d", m_screenWidth, m_screenHeight);
 
+#ifdef EGL
+	eglInitialize(eglGetDisplay(EGL_DEFAULT_DISPLAY), nullptr, nullptr);
+#endif // EGL
 
+	LOG(LOG_VERBOSE, "[GlideN64]: Create setting videomode %dx%d", m_screenWidth, m_screenHeight);
 	return true;
 }
 
@@ -86,7 +88,7 @@ void DisplayWindowMupen64plus::_swapBuffers()
 {
 	//Don't let the command queue grow too big buy waiting on no more swap buffers being queued
 	FunctionWrapper::WaitForSwapBuffersQueued();
-	
+
 	libretro_swap_buffer = true;
 }
 

--- a/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_Utils.cpp
@@ -27,6 +27,10 @@ bool Utils::isExtensionSupported(const opengl::GLInfo & _glinfo, const char *ext
 		return false;
 
 	const GLubyte *extensions = glGetString(GL_EXTENSIONS);
+	if (extensions == nullptr) {
+		LOG(LOG_WARNING, "[GlideN64]: could not query GL extensions on this device");
+		return false;
+	}
 
 	const GLubyte *start = extensions;
 	for (;;) {
@@ -52,6 +56,10 @@ bool Utils::isEGLExtensionSupported(const char * extension)
 		return false;
 
 	const char* extensions = eglQueryString(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_EXTENSIONS);
+	if (extensions == nullptr) {
+		LOG(LOG_WARNING, "[GlideN64]: could not query EGL extensions on this device");
+		return false;
+	}
 
 	const char* start = extensions;
 	for (;;) {


### PR DESCRIPTION
* Some devices need to call `eglInitialize()` first, e.g. Android.
* Some devices can return `null` in `eglQueryString()` which causes a nullptr segfault later. For these cases, simply return `false`.

Tested on RPI3B+ with DRM/KMS/EGL/Mesa.