### PR TITLE
Fix Raspberry Pi 4 build configuration (develop)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,11 @@ ifneq (,$(findstring unix,$(platform)))
 else ifneq (,$(findstring rpi,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined -ldl
-   GLES = 1
+   ifeq ($(FORCE_GLES3),1)
+      GLES3 = 1
+   else
+      GLES = 1
+   endif
    ifneq (,$(findstring mesa,$(platform)))
       MESA = 1
    endif

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,9 @@ else ifneq (,$(findstring rpi,$(platform)))
    else ifneq (,$(findstring rpi3,$(platform)))
       CPUFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
       HAVE_NEON = 1
+   else ifneq (,$(findstring rpi4,$(platform)))
+      CPUFLAGS += -march=armv8-a+crc -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard
+      HAVE_NEON = 1
    endif
    COREFLAGS += -DOS_LINUX
    ASFLAGS = -f elf -d ELF_TYPE

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,12 @@ else ifneq (,$(findstring rpi,$(platform)))
    LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined -ldl
    GLES = 1
    ifneq (,$(findstring mesa,$(platform)))
+      MESA = 1
+   endif
+   ifneq (,$(findstring rpi4,$(platform)))
+      MESA = 1
+   endif
+   ifeq ($(MESA), 1)
       GL_LIB := -lGLESv2
    else
       LLE = 0


### PR DESCRIPTION
This rebases #82 onto the `develop` branch. Commits related to fixing the extension-query crash have been removed in lieu of the fix from #94.

The following configurations are enabled / remain available:
```
make platform=rpi3  # to use old legacy driver for RPi3
make platform=rpi3-mesa  # to use new fkms/drm driver on RPi3
make platform=rpi4  # to use new fkms/drm driver on RPi4
make platform=rpi4 FORCE_GLES3=1  # to use new fkms/drm driver on RPi4 with OpenGL ES 3.0
```

The GLES3 implementation currently crashes on Raspbian Buster, and does not appear to be code-complete for reasons mentioned in https://github.com/libretro/mupen64plus-libretro-nx/pull/82#issuecomment-518290829 and https://github.com/libretro/mupen64plus-libretro-nx/pull/82#issuecomment-518301144. Fixing this may be best suited for a future PR and Pi 4 users can stick to `platform=rpi4` (GLES 2.0) for the time being.