### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ ifeq ($(DEBUG), 1)
 else
    CPUOPTS += -DNDEBUG -fsigned-char -ffast-math -fno-strict-aliasing -fomit-frame-pointer -fvisibility=hidden
 ifneq ($(platform), libnx)
-   CPUOPTS := -O2 $(CPUOPTS)
+   CPUOPTS := -O3 $(CPUOPTS)
 endif
    CXXFLAGS += -fvisibility-inlines-hidden
 endif
@@ -490,7 +490,7 @@ ifeq (,$(findstring android,$(platform)))
    LDFLAGS    += -lpthread
 endif
 
-LDFLAGS    += $(fpic) -O2 -lz -lpng $(CPUFLAGS)
+LDFLAGS    += $(fpic) -O3 -lz -lpng $(CPUFLAGS)
 
 all: $(TARGET)
 $(TARGET): $(OBJECTS)


### PR DESCRIPTION
- Add an option HAVE_LTCG we can set to enable LTO
- Optimize CPUFLAGS for Odroid-XU3/XU4
- Make sure we can override the BOARD variable (useful when cross-compiling or when running a mainline kernel which does not list the model in /proc/cpuinfo)
- Also add the CPUFLAGS when linking, this is required when the compiler/toolchain doesn't set the same default options
- Change default optimization from O2 to O3

This makes it possible to build with e.g.:
make HAVE_LTCG=1 ARCH=arm platform=odroid BOARD=ODROID-XU4