### PR TITLE
Add support for loading GL symbols using dlsym() instead of libretro API

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/GLFunctions.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/GLFunctions.cpp
@@ -5,11 +5,16 @@
 
 #include "GLFunctions.h"
 
-// For Libretro
 #define ASSIGN_PROC_ADR(proc_type, proc_name) ptr##proc_name = gl##proc_name
+#if defined(GL_USE_DLSYM)
+// Use dlsym() to load GL symbols from the default shared object search order
+#define GL_GET_PROC_ADR(proc_type, proc_name) ptr##proc_name = (proc_type) dlsym(RTLD_DEFAULT, "gl"#proc_name)
+#else
+// Use libretro API to load GL/EGL symbols
 #define glGetProcAddress glsm_get_proc_address
 #define GL_GET_PROC_ADR(proc_type, proc_name) ptr##proc_name = (proc_type) glGetProcAddress("gl"#proc_name)
 #define GL_GET_PROC_ADR_EGL(proc_type, proc_name) ptr##proc_name = (proc_type) glGetProcAddress("egl"#proc_name)
+#endif
 
 #if 0
 #ifdef OS_WINDOWS

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ else ifneq (,$(findstring rpi,$(platform)))
       GL_LIB := -lGLESv2
    else
       LLE = 0
-      CPUFLAGS += -DVC
+      COREFLAGS += -DVC -DGL_USE_DLSYM
       GL_LIB := -L/opt/vc/lib -lbrcmGLESv2
       EGL_LIB := -lbrcmEGL
       INCFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos -I/opt/vc/include/interface/vcos/pthreads

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mupen64Plus-Next is N64 emulation library for the [libretro API](http://www.libr
 
 It is also the successor of the old Mupen64Plus libretro core.
 
-> You can *always* rely on it to  give you a excellent Majora's Mask experience. Seriously.
+> You can *always* rely on it to give you an excellent Majora's Mask experience. Seriously.
 
 #### How is this different from any N64 libretro-core, ever?
 


### PR DESCRIPTION
* Required for platforms with EGL version < 1.5
* To enable, use new compile-time define: `-DGL_USE_DLSYM`

Currently only enabled for Raspberry Pi platforms that use the legacy Broadcom driver.
