### PR TITLE
[Reference] GLES2 doesn't support Async color copy

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -272,7 +272,7 @@ static void setup_variables(void)
         { CORE_NAME "-EnableLODEmulation",
             "(GLN64) LOD Emulation; True|False" },
         { CORE_NAME "-EnableCopyColorToRDRAM",
-#ifndef HAVE_OPENGLES
+#ifndef HAVE_OPENGLES2
             "(GLN64) Color buffer to RDRAM; Async|Sync|Off" },
 #else
             "(GLN64) Color buffer to RDRAM; Off|Async|Sync" },


### PR DESCRIPTION
HAVE_OPENGLES is enabled on GLES3 builds: https://github.com/jdonald/mupen64plus-libretro-nx/blob/develop/Makefile.common#L377

currently this incorrectly defaults this option off for GLES3, when it's only GLES2 devices that can't use it in async mode: https://github.com/gonetz/GLideN64/blob/0a5216f8e1e8dad7e73b9eaf32082b2313d2c501/src/Graphics/OpenGLContext/opengl_GLInfo.cpp#L141