### PR TITLE
Always return -1 from HleForwardTask

### DIFF
--- a/mupen64plus-rsp-hle/src/plugin.c
+++ b/mupen64plus-rsp-hle/src/plugin.c
@@ -144,7 +144,7 @@ void HleShowCFB(void* UNUSED(user_defined))
 
 int HleForwardTask(void* user_defined)
 {
-    return 0;
+    return -1;
 }
 
 /* DLL-exported functions */


### PR DESCRIPTION
We don't have LLE yet so this means we don't try to forward things to an LLE implementation. Fixes F-Zero X Expansion