### PR TITLE
Fix GCC10 build

### DIFF
--- a/mupen64plus-core/src/device/r4300/idec.h
+++ b/mupen64plus-core/src/device/r4300/idec.h
@@ -82,6 +82,6 @@ size_t idec_u53(uint32_t iw, uint8_t u53, uint8_t* u5);
 
 #define IDEC_U53(r4300, iw, u53, u5) (void*)(((char*)(r4300)) + idec_u53((iw), (u53), (u5)))
 
-const char* g_r4300_opcodes[R4300_OPCODES_COUNT];
+extern const char* g_r4300_opcodes[R4300_OPCODES_COUNT];
 
 #endif

--- a/mupen64plus-core/src/main/workqueue.h
+++ b/mupen64plus-core/src/main/workqueue.h
@@ -27,7 +27,7 @@
 
 struct work_struct;
 
-struct work_struct *work;
+extern struct work_struct *work;
 typedef void (*work_func_t)(struct work_struct *work);
 struct work_struct {
     work_func_t func;


### PR DESCRIPTION
GCC behavior became more strict in version 10.
>**Default to -fno-common**
>A common mistake in C is omitting extern when declaring a global variable in a header file. If the header is included by several files it results in multiple definitions of the same variable. In previous GCC versions this error is ignored. GCC 10 defaults to -fno-common, which means a linker error will now be reported. To fix this, use extern in header files when declaring global variables, and ensure each global is defined in exactly one C file. If tentative definitions of particular variables need to be placed in a common block, __attribute__((__common__)) can be used to force that behavior even in code compiled without -fcommon. As a workaround, legacy C code where all tentative definitions should be placed into a common block can be compiled with -fcommon.

      int x;  // tentative definition - avoid in header files
      extern int y;  // correct declaration in a header file
  

https://gcc.gnu.org/gcc-10/porting_to.html

Thanks to RealNC for pointing it out.