### PR TITLE
Fix Mac compilation issues

### DIFF
--- a/GLideN64/src/PaletteTexture.h
+++ b/GLideN64/src/PaletteTexture.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <memory>
 
-#ifdef IOS
+#if defined IOS || defined OSX
 #include <stdlib.h>
 #else
 #include <malloc.h>
-#endif // IOS
+#endif // IOS || OSX
 
 struct CachedTexture;
 

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ else ifneq (,$(findstring osx,$(platform)))
         LDFLAGS += -mmacosx-version-min=10.7
    LDFLAGS += -stdlib=libc++
 
-   PLATCFLAGS += -D__MACOSX__ -DOSX -DOS_MAC_OS_X
+   PLATCFLAGS += -D__MACOSX__ -DOSX -DOS_MAC_OS_X -fno-stack-check
    GL_LIB := -framework OpenGL
 
    # Target Dynarec
@@ -313,7 +313,7 @@ else ifneq (,$(findstring osx,$(platform)))
    endif
 
    COREFLAGS += -DOS_LINUX
-   ASFLAGS = -f elf -d ELF_TYPE
+   ASFLAGS = -f macho64 -d LEADING_UNDERSCORE
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
    ifeq ($(IOSSDK),)
@@ -538,8 +538,8 @@ $(AWK_DEST_DIR)/asm_defines_nasm.h: $(ASM_DEFINES_OBJ)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	find -name "*.o" -type f -delete
-	find -name "*.d" -type f -delete
+	find . -name "*.o" -type f -delete
+	find . -name "*.d" -type f -delete
 	rm -f $(TARGET)
 
 .PHONY: clean

--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -2500,7 +2500,11 @@ void rglProgramBinary(GLuint program,
 
 void rglTexImage2DMultisample( 	GLenum target,
   	GLsizei samples,
+#if defined(OSX)
+  	GLint internalformat,
+#else
   	GLenum internalformat,
+#endif
   	GLsizei width,
   	GLsizei height,
   	GLboolean fixedsamplelocations)

--- a/libretro-common/include/glsm/glsmsym.h
+++ b/libretro-common/include/glsm/glsmsym.h
@@ -435,7 +435,11 @@ void rglTexImage3D(	GLenum target,
  	const GLvoid * data);
 void rglTexImage2DMultisample( 	GLenum target,
   	GLsizei samples,
+#if defined(OSX)
+  	GLint internalformat,
+#else
   	GLenum internalformat,
+#endif
   	GLsizei width,
   	GLsizei height,
   	GLboolean fixedsamplelocations);


### PR DESCRIPTION
Fix the compilation hurdles mentioned in #146 and more.

I guess the change to GLideN64/src/PaletteTexture.h should be pushed upstream first.
However, according to the CI build status, https://github.com/libretro/GLideN64 already compiles on OSX...
I wonder if the travis environment include malloc.h some other way...