### PR TITLE
Use GLES3 for AMLG12/Odroid N2  platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,9 @@ else ifneq (,$(findstring odroid64,$(platform)))
    else ifneq (,$(findstring N2,$(BOARD)))
       # ODROID-N2
       CPUFLAGS += -mcpu=cortex-a73.cortex-a53
+      GLES = 0
+      GLES3= 1
+      GL_LIB := -lGLESv3
    endif
 
    COREFLAGS += -DOS_LINUX
@@ -249,16 +252,18 @@ else ifneq (,$(findstring AMLG,$(platform)))
          CPUFLAGS += -mtune=cortex-a53
       endif
       GLES3 = 1
+      GL_LIB := -lGLESv3
    else ifneq (,$(findstring AMLGX,$(platform)))
       CPUFLAGS += -mtune=cortex-a53
       ifneq (,$(findstring AMLGXM,$(platform)))
          GLES3 = 1
+         GL_LIB := -lGLESv3
       else
          GLES = 1
+         GL_LIB := -lGLESv2
       endif
    endif
-
-   GL_LIB := -lGLESv2
+  
    HAVE_NEON = 1
    WITH_DYNAREC=arm
    COREFLAGS += -DUSE_GENERIC_GLESV2 -DOS_LINUX


### PR DESCRIPTION
As discussed on https://github.com/libretro/mupen64plus-libretro-nx/issues/239

I tried to leave all the other platforms intact as I have no real idea how they are affected.