### PR TITLE
call the context matching the current driver

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
@@ -23,6 +23,11 @@ using namespace glsl;
 
 #define SHADER_STORAGE_FOLDER_NAME "shaders"
 
+extern "C" {
+	// TODO: Maybe add to common header, check for dupe declarations
+	extern struct retro_hw_render_callback hw_render;
+}
+
 static
 std::string getStorageFileName(const opengl::GLInfo & _glinfo, const char * _fileExtension)
 {
@@ -62,7 +67,16 @@ std::string getStorageFileName(const opengl::GLInfo & _glinfo, const char * _fil
 	if(_glinfo.isGLESX) {
 		strOpenGLType = "GLES";
 	} else {
-		strOpenGLType = "OpenGL";
+		// Distinction between GL and GL Core to avoid shader cache issues
+		switch(hw_render.context_type)
+		{
+			case RETRO_HW_CONTEXT_OPENGL_CORE:
+				strOpenGLType = "OpenGL_CORE";
+				break;
+			default:
+				strOpenGLType = "OpenGL";
+				break;
+		}
 	}
 
 	path << "/GLideN64." << std::hex << static_cast<u32>(std::hash<std::string>()(RSP.romname))

--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -3298,9 +3298,19 @@ static bool glsm_state_ctx_init(glsm_ctx_params_t *params)
 #endif
 #else
 #if defined(CORE) && !defined(HAVE_LIBNX)
-   hw_render.context_type       = RETRO_HW_CONTEXT_OPENGL_CORE;
-   hw_render.version_major      = 3;
-   hw_render.version_minor      = 3;
+   switch (params->context_type)
+   {
+      case RETRO_HW_CONTEXT_OPENGL:
+         hw_render.context_type    = RETRO_HW_CONTEXT_OPENGL;
+         hw_render.version_major   = 0;
+         hw_render.version_minor   = 0;
+         break;
+      default:
+         hw_render.context_type    = RETRO_HW_CONTEXT_OPENGL_CORE;
+         hw_render.version_major   = 3;
+         hw_render.version_minor   = 3;
+         break;
+   }
 #else
    hw_render.context_type       = RETRO_HW_CONTEXT_OPENGL;
    if (params->major != 0)


### PR DESCRIPTION
There are odd issues when switching from a gl to glcore and reverse... those issues seem to be solved if you let the game run for some time before restarting it. I believe there might be something that stays in cache after the core is closed.