### PR TITLE
Restore Haiku build

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/ThreadedOpenGl/atomicops.h
+++ b/GLideN64/src/Graphics/OpenGLContext/ThreadedOpenGl/atomicops.h
@@ -349,6 +349,8 @@ extern "C" {
 }
 #elif defined(__MACH__)
 #include <mach/mach.h>
+#elif defined(__HAIKU__)
+#include <posix/semaphore.h>
 #elif defined(__unix__) || defined(HAVE_LIBNX)
 #include <semaphore.h>
 #endif
@@ -483,7 +485,7 @@ namespace moodycamel
 				}
 			}
 		};
-#elif defined(__unix__) || defined(HAVE_LIBNX)
+#elif defined(__unix__) || defined(HAVE_LIBNX) || defined(__HAIKU__)
 		//---------------------------------------------------------
 		// Semaphore (POSIX, Linux)
 		//---------------------------------------------------------


### PR DESCRIPTION
Looks like these disappeared during a force push. This restores the Haiku build.