### PR TITLE
Current buildable gdbstub branch

### DIFF
--- a/GLideN64/src/PaletteTexture.h
+++ b/GLideN64/src/PaletteTexture.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <memory>
 
-#ifdef IOS
+#if defined IOS || defined(__APPLE__)
 #include <stdlib.h>
 #else
 #include <malloc.h>
-#endif // IOS
+#endif // IOS || __APPLE__
 
 struct CachedTexture;
 

--- a/Makefile
+++ b/Makefile
@@ -323,8 +323,6 @@ else ifneq (,$(findstring osx,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.dylib
    LDFLAGS += -dynamiclib
    OSXVER = `sw_vers -productVersion | cut -d. -f 2`
-   OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
-        LDFLAGS += -mmacosx-version-min=10.7
    LDFLAGS += -stdlib=libc++
 
    PLATCFLAGS += -D__MACOSX__ -DOSX -DOS_MAC_OS_X
@@ -336,7 +334,7 @@ else ifneq (,$(findstring osx,$(platform)))
    endif
 
    COREFLAGS += -DOS_LINUX
-   ASFLAGS = -f elf -d ELF_TYPE
+   ASFLAGS = -f macho64 -d LEADING_UNDERSCORE
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
    ifeq ($(IOSSDK),)
@@ -566,8 +564,8 @@ $(AWK_DEST_DIR)/asm_defines_nasm.h: $(ASM_DEFINES_OBJ)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	find -name "*.o" -type f -delete
-	find -name "*.d" -type f -delete
+	find . -name "*.o" -type f -delete
+	find . -name "*.d" -type f -delete
 	rm -f $(TARGET)
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -505,8 +505,20 @@ endif
 CPUOPTS += -fcommon
 
 ifeq ($(CORE_DEBUG), 1)
+   ifeq ($(MSYSTEM),MINGW32)
+      LIBOPCODES ?= /mingw32/lib/binutils/libopcodes.a
+      LIBBFD ?= /mingw32/lib/binutils/libbfd.a
+      LIBIBERTY ?= /mingw32/lib/binutils/libiberty.a
+      LDFLAGS += -lws2_32
+   else
+      # Where are these libs supposed to be found normally?
+      BINUTILS_BUILD_DIR ?= /Users/ethteck/binutils/build-binutils
+      LIBOPCODES ?= $(BINUTILS_BUILD_DIR)/opcodes/libopcodes.a
+      LIBBFD ?= $(BINUTILS_BUILD_DIR)/bfd/libbfd.a
+      LIBIBERTY ?= $(BINUTILS_BUILD_DIR)/libiberty/libiberty.a
+   endif
    COREFLAGS += -DDBG -DUSE_LIBOPCODES_GE_2_29 -DFMT_HEADER_ONLY
-   LDFLAGS += -mconsole -lws2_32 -lfmt /mingw32/lib/binutils/libopcodes.a /mingw32/lib/binutils/libbfd.a -lintl -lz /mingw32/lib/binutils/libiberty.a
+   LDFLAGS += -mconsole -lfmt $(LIBOPCODES) $(LIBBFD) -lintl -lz $(LIBIBERTY)
 endif
 
 # set C/C++ standard to use

--- a/custom/dependencies/libzlib/gzguts.h
+++ b/custom/dependencies/libzlib/gzguts.h
@@ -27,6 +27,10 @@
 #endif
 #include <fcntl.h>
 
+#ifdef __APPLE__
+#  include <unistd.h>
+#endif
+
 #ifdef _WIN32
 #  include <stddef.h>
 #endif

--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -2500,7 +2500,7 @@ void rglProgramBinary(GLuint program,
 
 void rglTexImage2DMultisample( 	GLenum target,
   	GLsizei samples,
-  	GLenum internalformat,
+  	GLint internalformat,
   	GLsizei width,
   	GLsizei height,
   	GLboolean fixedsamplelocations)

--- a/libretro-common/include/glsm/glsmsym.h
+++ b/libretro-common/include/glsm/glsmsym.h
@@ -435,7 +435,7 @@ void rglTexImage3D(	GLenum target,
  	const GLvoid * data);
 void rglTexImage2DMultisample( 	GLenum target,
   	GLsizei samples,
-  	GLenum internalformat,
+  	GLint internalformat,
   	GLsizei width,
   	GLsizei height,
   	GLboolean fixedsamplelocations);

--- a/mupen64plus-core/src/debugger/dbg_debugger.c
+++ b/mupen64plus-core/src/debugger/dbg_debugger.c
@@ -20,6 +20,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifdef __APPLE__
+#include <stdlib.h>
+#endif
+
 #include <semaphore.h>
 #include "api/callbacks.h"
 #include "api/debugger.h"

--- a/mupen64plus-core/src/debugger/gdbstub.cpp
+++ b/mupen64plus-core/src/debugger/gdbstub.cpp
@@ -80,7 +80,7 @@ using VAddr = u64;
 using u128 = std::array<std::uint64_t, 2>;
 static_assert(sizeof(u128) == 16, "u128 must be 128 bits wide");
 
-constexpr int GDB_BUFFER_SIZE = 10000;
+constexpr int GDB_BUFFER_SIZE = 4095;
 
 constexpr char GDB_STUB_START = '$';
 constexpr char GDB_STUB_END = '#';
@@ -118,7 +118,7 @@ constexpr char target_xml[] =
 <!DOCTYPE target SYSTEM "gdb-target.dtd">
 <target version="1.0">
 	<architecture>mips:4300</architecture>
-	<feature name="org.gnu.gdb.mips.cpu" idatitle="General registers">
+    <feature name="org.gnu.gdb.mips.cpu" idatitle="General registers">
 	  <reg name="zero" bitsize="64" type="data_ptr" regnum="0"/>
 	  <reg name="at" bitsize="64" type="data_ptr"/>
 	  <reg name="v0" bitsize="64" type="data_ptr"/>
@@ -151,12 +151,10 @@ constexpr char target_xml[] =
 	  <reg name="sp" bitsize="64" type="stack_ptr"/>
 	  <reg name="fp" bitsize="64" type="data_ptr"/>
 	  <reg name="ra" bitsize="64" type="data_ptr"/>
-
 	  <reg name="lo" bitsize="64" regnum="33"/>
 	  <reg name="hi" bitsize="64" regnum="34"/>
 	  <reg name="pc" bitsize="64" regnum="37" type="code_ptr"/>
 	</feature>
-
 	<feature name="org.gnu.gdb.mips.fpu">
 		<reg name="f0" bitsize="64" type="ieee_double" regnum="38"/>
 		<reg name="f1" bitsize="64" type="ieee_double"/>
@@ -1160,11 +1158,12 @@ void HandlePacket() {
                 if(!strcmp((char*)command_buffer, "vCont;s:1"))
                 {
                     Step();
+                    return;
                 }else if(strstr((char*)command_buffer, "vCont;c"))
                 {
                     Continue();
+                    return;
                 }
-                return;
             }
             
         default:


### PR DESCRIPTION
Applied changes from #256 to the win32_gdbstub branch (which has been rebased).

Currently, I am pointing to the binutils libs from my binutils build directory. The buinutils install process doesn't seem to copy these libs anywhere, which I'm not sure how to troubleshoot.