### PR TITLE
Disable Android X86 Dynarec

### DIFF
--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -44,12 +44,8 @@ else ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
   HAVE_PARALLEL_RDP = 1
   HAVE_THR_AL = 1
 else ifeq ($(TARGET_ARCH_ABI),x86)
-  # X86 dynarec isn't position independent, so it fails to build on newer ndks.
-  # No warn shared textrel allows it to build, but still won't allow it to run on api 23+.
-  WITH_DYNAREC := x86
   STRINGS := i686-linux-android-$(STRINGS)
-  COREASMFLAGS := -f elf -d ELF_TYPE
-  CORELDLIBS := -Wl,-no-warn-shared-textrel
+  COREFLAGS += -DNO_ASM
 else ifeq ($(TARGET_ARCH_ABI),x86_64)
   WITH_DYNAREC := x86_64
   STRINGS := x86_64-linux-android-$(STRINGS)


### PR DESCRIPTION
It is not PIC compliant and won't run on api 23+. NDK r22 uses a different flag to ignore shared textrels. But better to drop the dynarec entirely since the number of devices running <= api 23 and x86 userspace is pretty low at this point.