### PR TITLE
Makefile: added Mesa OpenGL ES opts for platform AML & RK / use correct libGLESv2 for standard builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,16 +282,23 @@ else ifneq (,$(findstring AMLG,$(platform)))
          CPUFLAGS += -mtune=cortex-a53
       endif
       GLES3 = 1
-      GL_LIB := -lGLESv3
    else ifneq (,$(findstring AMLGX,$(platform)))
       CPUFLAGS += -mtune=cortex-a53
       ifneq (,$(findstring AMLGXM,$(platform)))
          GLES3 = 1
-         GL_LIB := -lGLESv3
       else
          GLES = 1
-         GL_LIB := -lGLESv2
       endif
+   endif
+
+   ifneq (,$(findstring mesa,$(platform)))
+      COREFLAGS += -DEGL_NO_X11
+   endif
+
+   ifneq (,$(findstring mali,$(platform)))
+      GL_LIB := -lGLESv3
+   else
+      GL_LIB := -lGLESv2
    endif
   
    HAVE_NEON = 1
@@ -328,6 +335,10 @@ else ifneq (,$(findstring RK,$(platform)))
    else ifneq (,$(findstring RK3288,$(platform)))
       CPUFLAGS += -march=armv7ve -mtune=cortex-a17 -mfloat-abi=hard -mfpu=neon-vfpv4
       GLES3 = 1
+   endif
+
+   ifneq (,$(findstring mesa,$(platform)))
+      COREFLAGS += -DEGL_NO_X11
    endif
 
    GL_LIB := -lGLESv2


### PR DESCRIPTION
This issue https://github.com/libretro/mupen64plus-libretro-nx/issues/239 lead to https://github.com/libretro/mupen64plus-libretro-nx/pull/246 but this is only valid for some non-standard vendor blob packages e.g. https://github.com/EmuELEC/EmuELEC/blob/master/packages/graphics/opengl-meson/package.mk#L31-L33

According to libglvnd & mesa:
```
Khronos recommends that the GLES 3.1 library also be called libGLESv2.
It also requires that functions be statically linkable from that
library.
```

Sources:
https://www.khronos.org/registry/implementers_guide.html#idm58020557104
https://github.com/NVIDIA/libglvnd/issues/44
https://github.com/mesa3d/mesa/commit/5921f372c89a68fac6ddefc009442721d9df4db2

So my PR adds platform flags for mesa & mali builds and reverts to default `libGLESv2` for all other builds.

@shantigilbert have a look at these changes because after them you'll need platform flags for some of your builds
