### PR TITLE
Add ANGLE support to the upstream Mupen Libretro core

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/GLFunctions.h
+++ b/GLideN64/src/Graphics/OpenGLContext/GLFunctions.h
@@ -54,7 +54,9 @@ typedef void (APIENTRYP PFNGLDELETETEXTURESPROC) (GLsizei n, const GLuint *textu
 typedef void (APIENTRYP PFNGLGENTEXTURESPROC) (GLsizei n, GLuint *textures);
 typedef void (APIENTRYP PFNGLCOPYTEXIMAGE2DPROC) (GLenum target, GLint level, GLenum internalformat, GLint x, GLint y, GLsizei width, GLsizei height, GLint border);
 #endif
-
+#ifdef HAVE_ANGLE
+typedef void (APIENTRYP PFNGLTEXTURESTORAGE2DMULTISAMPLEEXTPROC)(GLuint texture, GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLboolean fixedsamplelocations);
+#endif
 extern PFNGLBLENDFUNCPROC ptrBlendFunc;
 extern PFNGLBLENDFUNCSEPARATEPROC ptrBlendFuncSeparate;
 extern PFNGLPIXELSTOREIPROC ptrPixelStorei;

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DEBUG = 0
 FORCE_GLES ?= 0
 FORCE_GLES3 ?= 0
+HAVE_ANGLE?=0
 LLE ?= 0
 HAVE_PARALLEL_RSP ?= 0
 HAVE_PARALLEL_RDP ?= 0
@@ -478,7 +479,17 @@ else ifeq ($(platform), emscripten)
 else
    TARGET := $(TARGET_NAME)_libretro.dll
    LDFLAGS += -shared -static-libgcc -static-libstdc++ -Wl,--version-script=$(LIBRETRO_DIR)/link.T #-static -lmingw32 -lSDL2main -lSDL2 -mwindows -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid  -lsdl2_net -lsdl2 -lws2_32 -lSetupapi -lIPHLPAPI
-   GL_LIB := -lopengl32
+   ifeq ($(HAVE_ANGLE),1)
+      GLES3 = 1
+      INCFLAGS += -I$(ROOT_DIR)/../ANGLE/include
+      GL_LIB = -L$(ROOT_DIR)/../ANGLE -lGLESv2
+      EGL_LIB = -L$(ROOT_DIR)/../ANGLE -lEGL
+      COREFLAGS += -g 
+   else
+      GL_LIB := -lopengl32
+   endif
+   
+   
    
    ifeq ($(MSYSTEM),MINGW64)
       CC ?= x86_64-w64-mingw32-gcc
@@ -496,8 +507,10 @@ else
       ASFLAGS = -f win32 -d WIN32 -d LEADING_UNDERSCORE
    endif
 
-   HAVE_PARALLEL_RSP = 1
-   HAVE_PARALLEL_RDP = 1
+   ifeq ($(HAVE_ANGLE),0)
+   	HAVE_PARALLEL_RSP = 1
+   	HAVE_PARALLEL_RDP = 1
+   endif
    HAVE_THR_AL = 1
    LLE = 1
    COREFLAGS += -DOS_WINDOWS -DMINGW
@@ -525,6 +538,10 @@ ifeq ($(LLE), 1)
 endif
 
 COREFLAGS += -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -D__LIBRETRO__ -DUSE_FILE32API -DM64P_PLUGIN_API -DM64P_CORE_PROTOTYPES -D_ENDUSER_RELEASE -DSINC_LOWER_QUALITY -DTXFILTER_LIB -D__VEC4_OPT -DMUPENPLUSAPI
+   ifeq ($(HAVE_ANGLE),1)
+      COREFLAGS += -DHAVE_ANGLE
+
+   endif
 
 ifeq ($(DEBUG), 1)
    CPUOPTS += -O0 -g

--- a/README.md
+++ b/README.md
@@ -38,5 +38,14 @@ A special thanks to:
 - themaister for parallel-rsp and parallel-rdp (including the Vulkan integration)
 - Everyone in the libretro Team
 
+#### How to build with ANGLE
+
+Build:
+make HAVE_ANGLE=1
+
+Requirements:
+Create an folder named "ANGLE" in the parent directory of the mupen source.
+Place libEGL.dll and libGLESv2.dll in that folder.(can be obtained from retroarch itself).
+Copy include folder from ANGLE source into the ANGLE folder.
 
 \- m4xw


### PR DESCRIPTION
This was done by JustMeDaFaq (https://github.com/JustMeDaFaq) and makes it easier to build the ANGLE version of the core for Xbox.  The core built from this source has been tested and it also works with Angrylion.