### PR TITLE
Add sys/types.h for u_int declaration

### DIFF
--- a/mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c
@@ -23,9 +23,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <sys/types.h>
 
 #if defined(__APPLE__)
-#include <sys/types.h> // needed for u_int, u_char, etc
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 


### PR DESCRIPTION
On musl libc which is strictier POSIX compliant than glibc, the u_int types are not available (as specified by POSIX) unless you include sys/types.h

This commit fix the build on musl, and since it's mandatory remove it so Apple builds get it by default too.