### PR TITLE
[GLN64] Add EnableTexCoordBounds core option

### DIFF
--- a/GLideN64/src/Config.cpp
+++ b/GLideN64/src/Config.cpp
@@ -59,7 +59,7 @@ void Config::resetToDefaults()
 	graphics2D.correctTexrectCoords = tcDisable;
 	graphics2D.enableNativeResTexrects = NativeResTexrectsMode::ntDisable;
 	graphics2D.bgMode = BGMode::bgOnePiece;
-	graphics2D.enableTexCoordBounds = 1;
+	graphics2D.enableTexCoordBounds = 0;
 
 	frameBufferEmulation.enable = 1;
 	frameBufferEmulation.copyDepthToRDRAM = cdSoftwareRender;

--- a/custom/GLideN64/mupenplus/Config_mupenplus.cpp
+++ b/custom/GLideN64/mupenplus/Config_mupenplus.cpp
@@ -199,6 +199,7 @@ extern "C" void Config_LoadConfig()
 	config.frameBufferEmulation.overscanPAL.bottom = OverscanBottom;
 
 	config.graphics2D.correctTexrectCoords = CorrectTexrectCoords;
+	config.graphics2D.enableTexCoordBounds = EnableTexCoordBounds;
 	config.graphics2D.enableNativeResTexrects = enableNativeResTexrects;
 
 	config.graphics2D.bgMode = BackgroundMode;

--- a/custom/mupen64plus-next_common.h
+++ b/custom/mupen64plus-next_common.h
@@ -91,6 +91,7 @@ extern uint32_t EnableDitheringQuantization;
 extern uint32_t RDRAMImageDitheringMode;
 extern uint32_t EnableHWLighting;
 extern uint32_t CorrectTexrectCoords;
+extern uint32_t EnableTexCoordBounds;
 extern uint32_t enableNativeResTexrects;
 extern uint32_t enableLegacyBlending;
 extern uint32_t EnableCopyColorToRDRAM;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -163,6 +163,7 @@ uint32_t RDRAMImageDitheringMode = 0;
 uint32_t EnableDitheringQuantization = 0;
 uint32_t EnableHWLighting = 0;
 uint32_t CorrectTexrectCoords = 0;
+uint32_t EnableTexCoordBounds = 0;
 uint32_t enableNativeResTexrects = 0;
 uint32_t enableLegacyBlending = 0;
 uint32_t EnableCopyColorToRDRAM = 0;
@@ -1016,6 +1017,13 @@ static void update_variables(bool startup)
              CorrectTexrectCoords = 1;
           else
              CorrectTexrectCoords = 0;
+       }
+
+       var.key = CORE_NAME "-EnableTexCoordBounds";
+       var.value = NULL;
+       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+       {
+          EnableTexCoordBounds = !strcmp(var.value, "False") ? 0 : 1;
        }
 
        var.key = CORE_NAME "-BackgroundMode";

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -362,6 +362,17 @@ struct retro_core_option_definition option_defs_us[] = {
         "Off"
     },
     {
+        CORE_NAME "-EnableTexCoordBounds",
+        "Enable native-res boundaries for texture coordinates",
+        "(GLN64) Bound texture rectangle texture coordinates to the values they take in native resolutions. It prevents garbage due to fetching out of texture bounds, but can result in hard edges.",
+        {
+            {"False", NULL},
+            {"True", NULL},
+            {NULL, NULL},
+        },
+        "False"
+    },
+    {
         CORE_NAME "-EnableNativeResTexrects",
         "Native res. 2D texrects",
         "(GLN64) Render 2D texrects in native resolution to fix misalignment between parts of 2D image (example: Mario Kart driver selection portraits).",


### PR DESCRIPTION
Example with Ogre Battle (left and bottom of the text box):

OFF:

![image](https://user-images.githubusercontent.com/33353403/125788547-4ec96352-7744-467f-89df-5c6a8a1c4c97.png)

ON:

![image](https://user-images.githubusercontent.com/33353403/125788589-7288b188-4e3c-4250-abc0-ae7c33ca50c5.png)

I used the name and the description from https://github.com/libretro/mupen64plus-libretro-nx/blob/a3801217629d6affc6a7ffa4e620d84e22b4ee64/GLideN64/src/GLideNUI/configDialog.ui#L1550-L1553

![image](https://user-images.githubusercontent.com/33353403/125788726-e3aa5f27-fed0-452d-b51e-981400516aeb.png)

Hope this is fine!