### PR TITLE
Restore Haiku 32bit build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ endif
 WITH_DYNAREC ?= $(ARCH)
 
 PIC = 1
+# on 32bit Haiku the output of "uname -m" is "BePC"
 ifeq ($(ARCH), $(filter $(ARCH), i386 i686 BePC))
    WITH_DYNAREC = x86
    PIC = 0

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 WITH_DYNAREC ?= $(ARCH)
 
 PIC = 1
-ifeq ($(ARCH), $(filter $(ARCH), i386 i686))
+ifeq ($(ARCH), $(filter $(ARCH), i386 i686 BePC))
    WITH_DYNAREC = x86
    PIC = 0
 else ifeq ($(ARCH), $(filter $(ARCH), arm))


### PR DESCRIPTION
This allows restoring the build for the 32bit version of the Haiku operating system