### PR TITLE
fix building on M1 macOS

### DIFF
--- a/GLideN64/src/PaletteTexture.h
+++ b/GLideN64/src/PaletteTexture.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <memory>
 
-#ifdef IOS
+#if defined(IOS) || defined(OSX)
 #include <stdlib.h>
 #else
 #include <malloc.h>
-#endif // IOS
+#endif
 
 struct CachedTexture;
 

--- a/Makefile
+++ b/Makefile
@@ -367,6 +367,12 @@ else ifneq (,$(findstring osx,$(platform)))
 
    COREFLAGS += -DOS_LINUX
    ASFLAGS = -f elf -d ELF_TYPE
+
+   ifeq ($(ARCH), x86_64)
+      CC = clang -arch x86_64
+      CXX = clang++ -arch x86_64
+      WITH_DYNAREC =
+   endif
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
    ifeq ($(IOSSDK),)

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ else ifneq (,$(findstring osx,$(platform)))
         LDFLAGS += -mmacosx-version-min=10.7
    LDFLAGS += -stdlib=libc++
 
-   PLATCFLAGS += -D__MACOSX__ -DOSX -DOS_MAC_OS_X
+   PLATCFLAGS += -D__MACOSX__ -DOSX -DOS_MAC_OS_X -DDONT_WANT_ARM_OPTIMIZATIONS -DNO_ASM -DHAVE_POSIX_MEMALIGN -Wno-error=implicit-function-declaration -Wno-deprecated-declarations
    GL_LIB := -framework OpenGL
 
    # Target Dynarec
@@ -597,8 +597,8 @@ $(AWK_DEST_DIR)/asm_defines_nasm.h: $(ASM_DEFINES_OBJ)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	find -name "*.o" -type f -delete
-	find -name "*.d" -type f -delete
+	find . -name "*.o" -type f -delete
+	find . -name "*.d" -type f -delete
 	rm -f $(TARGET)
 
 .PHONY: clean

--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -2500,7 +2500,7 @@ void rglProgramBinary(GLuint program,
 
 void rglTexImage2DMultisample( 	GLenum target,
   	GLsizei samples,
-  	GLenum internalformat,
+  	GLint internalformat,
   	GLsizei width,
   	GLsizei height,
   	GLboolean fixedsamplelocations)

--- a/libretro-common/include/glsm/glsmsym.h
+++ b/libretro-common/include/glsm/glsmsym.h
@@ -435,7 +435,7 @@ void rglTexImage3D(	GLenum target,
  	const GLvoid * data);
 void rglTexImage2DMultisample( 	GLenum target,
   	GLsizei samples,
-  	GLenum internalformat,
+  	GLint internalformat,
   	GLsizei width,
   	GLsizei height,
   	GLboolean fixedsamplelocations);


### PR DESCRIPTION
This PR allows the core to build on macOS arm64 (Apple silicon). Note that at present this isn't very helpful because retroarch releases on M1 aren't built with gl or vulkan support..