### PR TITLE
[RFC] Fix Parallel-RDP on Intel Xe

### DIFF
--- a/mupen64plus-video-paraLLEl/parallel-rdp/vulkan/device.cpp
+++ b/mupen64plus-video-paraLLEl/parallel-rdp/vulkan/device.cpp
@@ -4346,7 +4346,19 @@ BufferHandle Device::create_imported_host_buffer(const BufferCreateInfo &create_
 		return BufferHandle{};
 	}
 
-	uint32_t memory_type = find_memory_type(create_info.domain, reqs.memoryTypeBits);
+	uint32_t memory_type = UINT32_MAX;
+	if (gpu_props.vendorID == 0x8086 && gpu_props.driverVersion >= 0x1926a6) 
+	{
+		//Intel driver workaround for incorrect propertyFlags being returned for memoryTypes entries.
+		//Default to memoryTypes[2] which is best match based off vulkaninfo values.
+		//TODO: Revisit checks if Intel fix bug.
+		memory_type = 2;
+	}
+	else
+	{
+		memory_type = find_memory_type(create_info.domain, reqs.memoryTypeBits);
+	}
+
 	if (memory_type == UINT32_MAX)
 	{
 		LOGE("Failed to find memory type.\n");


### PR DESCRIPTION
As noted in #383 ParaLLel-RDP crashes on current Intel Xe drivers. On newer drivers vkGetPhysicalDeviceMemoryProperties calls incorrectly populates the VkPhysicalDeviceMemoryProperties struct values meaning that all contained memoryTypes->propertyFlags fields return 1 instead of the or'd flag values.
This means that the find_memory_type method's lookups will never match based on the expected flags, the rdram buffer is not initialized and it crashes out.

This will force set the memoryTypes index to the appropriate value bypassing the lookup method if the driver vendor is Intel and the version is at least the current most one, 30.0.100.9862.