### PR TITLE
Linux gdbstub Support

### DIFF
--- a/GLideN64/src/inc/GL/glext.h
+++ b/GLideN64/src/inc/GL/glext.h
@@ -1501,7 +1501,7 @@ typedef void (APIENTRYP PFNGLGETSYNCIVPROC) (GLsync sync, GLenum pname, GLsizei 
 typedef void (APIENTRYP PFNGLGETINTEGER64I_VPROC) (GLenum target, GLuint index, GLint64 *data);
 typedef void (APIENTRYP PFNGLGETBUFFERPARAMETERI64VPROC) (GLenum target, GLenum pname, GLint64 *params);
 typedef void (APIENTRYP PFNGLFRAMEBUFFERTEXTUREPROC) (GLenum target, GLenum attachment, GLuint texture, GLint level);
-typedef void (APIENTRYP PFNGLTEXIMAGE2DMULTISAMPLEPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLboolean fixedsamplelocations);
+typedef void (APIENTRYP PFNGLTEXIMAGE2DMULTISAMPLEPROC) (GLenum target, GLsizei samples, GLint internalformat, GLsizei width, GLsizei height, GLboolean fixedsamplelocations);
 typedef void (APIENTRYP PFNGLTEXIMAGE3DMULTISAMPLEPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
 typedef void (APIENTRYP PFNGLGETMULTISAMPLEFVPROC) (GLenum pname, GLuint index, GLfloat *val);
 typedef void (APIENTRYP PFNGLSAMPLEMASKIPROC) (GLuint maskNumber, GLbitfield mask);

--- a/Makefile
+++ b/Makefile
@@ -545,7 +545,11 @@ ifeq ($(CORE_DEBUG), 1)
       LIBOPCODES ?= /mingw32/lib/binutils/libopcodes.a
       LIBBFD ?= /mingw32/lib/binutils/libbfd.a
       LIBIBERTY ?= /mingw32/lib/binutils/libiberty.a
-      LDFLAGS += -lws2_32
+      LDFLAGS += -lws2_32 -mconsole -lintl
+  else ifeq ($(platform),unix)
+      LIBOPCODES ?= /usr/lib/libopcodes.a
+      LIBBFD ?= /usr/lib/libbfd.a
+      LIBIBERTY ?= /usr/lib/libiberty.a
    else
       # Where are these libs supposed to be found normally?
       BINUTILS_BUILD_DIR ?= /Users/ethteck/binutils/build-binutils
@@ -554,7 +558,11 @@ ifeq ($(CORE_DEBUG), 1)
       LIBIBERTY ?= $(BINUTILS_BUILD_DIR)/libiberty/libiberty.a
    endif
    COREFLAGS += -DDBG -DUSE_LIBOPCODES_GE_2_29 -DFMT_HEADER_ONLY
-   LDFLAGS += -mconsole -lfmt $(LIBOPCODES) $(LIBBFD) -lintl -lz $(LIBIBERTY)
+   LDFLAGS += -lfmt $(LIBOPCODES) $(LIBBFD) -lz
+   ifeq ($(platform),unix)
+      LDFLAGS += -ldl
+   endif
+   LDFLAGS += $(LIBIBERTY)
 endif
 
 # set C/C++ standard to use

--- a/mupen64plus-core/src/debugger/dbg_debugger.c
+++ b/mupen64plus-core/src/debugger/dbg_debugger.c
@@ -70,7 +70,7 @@ void destroy_debugger()
 {
     sem_destroy(sem_pending_steps);
     free(sem_pending_steps);
-    sem_pending_steps = NULL;
+    sem_pending_steps = 0;
     g_DebuggerActive = 0;
 }
 

--- a/mupen64plus-core/src/debugger/dbg_memory.c
+++ b/mupen64plus-core/src/debugger/dbg_memory.c
@@ -40,7 +40,7 @@
 
 /* we must define PACKAGE so that bfd.h (which is included from dis-asm.h) doesn't throw an error */
 #define PACKAGE "mupen64plus-core"
-#include <binutils/dis-asm.h>
+#include <dis-asm.h>
 #include <stdarg.h>
 
 static int  lines_recompiled;

--- a/mupen64plus-core/src/debugger/gdbstub.cpp
+++ b/mupen64plus-core/src/debugger/gdbstub.cpp
@@ -52,7 +52,7 @@ void debugger_update(unsigned int pc);
 }
 
 #include <mupen64plus-next_common.h>
-
+#include <vector>
 //#define LOG_ERROR(...)
 #define LOG_ERROR(...) GDBStub::FormatMsg(M64MSG_ERROR, __VA_ARGS__)
 //#define LOG_DEBUG(...)


### PR DESCRIPTION
These are changes required for getting the gdbstub branch to build on Linux. Most of it is just brute force modifications to get rid of error messages. The Makefile is a bit less hackish and _should_ keep support for building on win32 and macOS.

If any changes are needed to keep it working on win32 and macOS feel free to add commits, or tell me what needs fixed.