### PR TITLE
Core option visibility fixes/improvements

### DIFF
--- a/custom/mupen64plus-next_common.h
+++ b/custom/mupen64plus-next_common.h
@@ -83,8 +83,8 @@ extern void gln64_thr_gl_invoke_command_loop();
 extern bool threaded_gl_safe_shutdown;
 
 // Core options
-extern uint32_t CoreOptionVersion;
 extern uint32_t CoreOptionCategoriesSupported;
+extern uint32_t CoreOptionUpdateDisplayCbSupported;
 // GLN64
 extern uint32_t bilinearMode;
 extern uint32_t EnableHybridFilter;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <compat/strl.h>
 
 #include "libretro.h"
 #include "libretro_private.h"
@@ -144,6 +145,8 @@ uint32_t screen_pitch = 0;
 
 float retro_screen_aspect = 4.0 / 3.0;
 
+static char rdp_plugin_last[32] = {0};
+
 // Savestate globals
 bool retro_savestate_complete = false;
 int  retro_savestate_result = 0;
@@ -156,8 +159,8 @@ char* retro_dd_path_rom = NULL;
 char* retro_transferpak_rom_path = NULL;
 char* retro_transferpak_ram_path = NULL;
 
-uint32_t CoreOptionVersion = 0;
 uint32_t CoreOptionCategoriesSupported = 0;
+uint32_t CoreOptionUpdateDisplayCbSupported = 0;
 uint32_t bilinearMode = 0;
 uint32_t EnableHybridFilter = 0;
 uint32_t EnableDitheringPattern = 0;
@@ -242,8 +245,95 @@ static void n64DebugCallback(void* aContext, int aLevel, const char* aMessage)
 
 extern m64p_rom_header ROM_HEADER;
 
+static bool set_variable_visibility(void)
+{
+    // For simplicity we create a prepared var per plugin, maybe create a macro for this?
+    struct retro_core_option_display option_display_gliden64;
+    struct retro_core_option_display option_display_angrylion;
+    struct retro_core_option_display option_display_parallel_rdp;
+
+    size_t i;
+    size_t num_options = 0;
+    char **values_buf = NULL;
+    struct retro_variable var;
+    const char *rdp_plugin_current = "__NULL__";
+    bool rdp_plugin_found = false;
+
+    // If option categories are supported but
+    // the option update display callback is not,
+    // then all options should be shown,
+    // i.e. do nothing
+    if (CoreOptionCategoriesSupported && !CoreOptionUpdateDisplayCbSupported)
+        return false;
+
+    // Get current plugin
+    var.key = CORE_NAME "-rdp-plugin";
+    var.value = NULL;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+    {
+        rdp_plugin_current = var.value;
+        rdp_plugin_found = true;
+    }
+
+    // Check if plugin has changed since last
+    // call of this function
+    if (!strcmp(rdp_plugin_last, rdp_plugin_current))
+        return false;
+
+    strlcpy(rdp_plugin_last, rdp_plugin_current, sizeof(rdp_plugin_last));
+
+    // Show/hide options depending on Plugins (Active isn't relevant!)
+    if (rdp_plugin_found)
+    {
+        option_display_gliden64.visible = !strcmp(rdp_plugin_current, "gliden64");
+        option_display_angrylion.visible = !strcmp(rdp_plugin_current, "angrylion");
+        option_display_parallel_rdp.visible = !strcmp(rdp_plugin_current, "parallel");
+    } else {
+        option_display_gliden64.visible = option_display_angrylion.visible = option_display_parallel_rdp.visible = true;
+    }
+
+    // Determine number of options
+    for (;;)
+    {
+        if (!option_defs_us[num_options].key)
+            break;
+        num_options++;
+    }
+
+    // Copy parameters from option_defs_us array
+    for (i = 0; i < num_options; i++)
+    {
+        const char *key  = option_defs_us[i].key;
+        const char *hint = option_defs_us[i].info;
+        if (hint)
+        {
+            // Quick and dirty, its the only consistent naming
+            // Otherwise GlideN64 Setting keys will need to be broken again..
+            if (!!strstr(hint, "(GLN64)"))
+            {
+                option_display_gliden64.key = key;
+                environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display_gliden64);
+            } else if (!!strstr(hint, "(AL)"))
+            {
+                option_display_angrylion.key = key;
+                environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display_angrylion);
+            } else if (!!strstr(key, "parallel-rdp")) // Maybe unify it later?
+            {
+                option_display_parallel_rdp.key = key;
+                environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display_parallel_rdp);
+            }
+        }
+    }
+
+    return true;
+}
+
 static void setup_variables(void)
 {
+    bool categoriesSupported = false;
+    bool updateDisplayCbSupported = false;
+    struct retro_core_options_update_display_callback updateDisplayCb;
+
     static const struct retro_controller_description port[] = {
         { "Controller", RETRO_DEVICE_JOYPAD },
         { "RetroPad", RETRO_DEVICE_JOYPAD },
@@ -257,67 +347,18 @@ static void setup_variables(void)
         { 0, 0 }
     };
 
-    libretro_set_core_options(environ_cb, (bool*)&CoreOptionCategoriesSupported);
+    libretro_set_core_options(environ_cb, &categoriesSupported);
+    if (categoriesSupported)
+        CoreOptionCategoriesSupported = 1;
+
+    updateDisplayCb.callback = set_variable_visibility;
+    updateDisplayCbSupported = environ_cb(
+            RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK,
+            &updateDisplayCb);
+    if (updateDisplayCbSupported)
+        CoreOptionUpdateDisplayCbSupported = 1;
+
     environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
-}
-
-// Deprecated with Core Option Categories
-static void set_variable_visibility(void)
-{
-   // For simplicity we create a prepared var per plugin, maybe create a macro for this?
-   struct retro_core_option_display option_display_gliden64;
-   struct retro_core_option_display option_display_angrylion;
-   struct retro_core_option_display option_display_parallel_rdp;
-
-   size_t i;
-   size_t num_options = 0;
-   char **values_buf = NULL;
-   struct retro_variable var;
-
-   // Show/hide options depending on Plugins (Active isn't relevant!)
-   var.key = CORE_NAME "-rdp-plugin";
-   var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      option_display_gliden64.visible = !strcmp(var.value, "gliden64");
-      option_display_angrylion.visible = !strcmp(var.value, "angrylion");
-      option_display_parallel_rdp.visible = !strcmp(var.value, "parallel");
-   } else {
-      option_display_gliden64.visible = option_display_angrylion.visible = option_display_parallel_rdp.visible = true;
-   }
-
-   // Determine number of options
-   for (;;)
-   {
-      if (!option_defs_us[num_options].key)
-         break;
-      num_options++;
-   }
-
-   // Copy parameters from option_defs_us array
-   for (i = 0; i < num_options; i++)
-   {
-      const char *key  = option_defs_us[i].key;
-      const char *hint = option_defs_us[i].info;
-      if(hint)
-      {
-         // Quick and dirty, its the only consistent naming
-         // Otherwise GlideN64 Setting keys will need to be broken again..
-         if(!!strstr(hint, "(GLN64)"))
-         {
-            option_display_gliden64.key = key;
-            environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display_gliden64);
-         } else if(!!strstr(hint, "(AL)"))
-         {
-            option_display_angrylion.key = key;
-            environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display_angrylion);
-         } else if(!!strstr(key, "parallel-rdp")) // Maybe unify it later?
-         {
-            option_display_parallel_rdp.key = key;
-            environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display_parallel_rdp);
-         }
-      }
-   } 
 }
 
 static void cleanup_global_paths()
@@ -702,6 +743,10 @@ void retro_deinit(void)
 
     if (perf_cb.perf_log)
         perf_cb.perf_log();
+
+    rdp_plugin_last[0] = '\0';
+    CoreOptionCategoriesSupported = 0;
+    CoreOptionUpdateDisplayCbSupported = 0;
 }
 
 void update_controllers()
@@ -1686,9 +1731,8 @@ static void update_variables(bool startup)
 
     update_controllers();
 
-    // Compat hiding of options
-    if(!CoreOptionCategoriesSupported)
-      set_variable_visibility();
+    // Hide irrelevant options
+    set_variable_visibility();
 }
 
 static void format_saved_memory(void)

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -65,6 +65,25 @@ struct retro_core_option_v2_category option_cats_us[] = {
 
 struct retro_core_option_v2_definition option_defs_us[] = {
     {
+        CORE_NAME "-rdp-plugin",
+        "RDP Plugin",
+        NULL,
+        "Select a RDP Plugin, use Angrylion (if available) for best compability, GLideN64 for Performance",
+        NULL,
+        NULL,
+        {
+#ifdef HAVE_THR_AL
+            {"angrylion", "Angrylion"},
+#endif
+#ifdef HAVE_PARALLEL_RDP
+            {"parallel", "ParaLLEl-RDP"},
+#endif
+            {"gliden64", "GLideN64"},
+            { NULL, NULL },
+        },
+        "gliden64"
+    },
+    {
         CORE_NAME "-43screensize",
         "4:3 Resolution",
         NULL,
@@ -1359,25 +1378,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
 #endif
     },
     {
-        CORE_NAME "-rdp-plugin",
-        "RDP Plugin",
-        NULL,
-        "Select a RDP Plugin, use Angrylion (if available) for best compability, GLideN64 for Performance",
-        NULL,
-        NULL,
-        {
-#ifdef HAVE_THR_AL
-            {"angrylion", "Angrylion"},
-#endif
-#ifdef HAVE_PARALLEL_RDP
-            {"parallel", "ParaLLEl-RDP"},
-#endif
-            {"gliden64", "GLideN64"},
-            { NULL, NULL },
-        },
-        "gliden64"
-    },
-    {
         CORE_NAME "-rsp-plugin",
         "RSP Plugin",
         NULL,
@@ -1759,8 +1759,6 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
 
    if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
       version = 0;
-
-   CoreOptionVersion = version;
 
    if (version >= 2)
    {


### PR DESCRIPTION
This PR makes the following improvements to the display of core options:

- The visibility of RDP plugin options is now handled correctly on frontends with core option category support (at present all options are shown at startup, with irrelevant options only being hidden when any option changes)
- On frontends that support the `RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK` environment callback, RDP plugin option visibility is now updated in real-time as the `RDP Plugin` setting is changed in the menu
- The `RDP Plugin` core option has been moved to the top of the options list to prevent arbitrary 'jumping' of the menu navigation cursor when options are hidden/shown