### PR TITLE
Add CFBD audio distortion effect emulation.

### DIFF
--- a/mupen64plus-rsp-hle/src/alist.c
+++ b/mupen64plus-rsp-hle/src/alist.c
@@ -1022,3 +1022,17 @@ void alist_iirf(
     dram_store_u16(hle, (uint16_t*)&ibuf[(index-1)&3], address+10, 2);
 }
 
+void alist_overload(struct hle_t* hle, uint16_t dmem, int16_t count, int16_t gain, int16_t attenuation)
+{
+    int16_t accu;
+    int16_t * sample = (int16_t*)(hle->alist_buffer + dmem);
+
+    while (count != 0)
+    {
+        accu = clamp_s16(*sample * gain);
+        *sample = (accu * attenuation) >> 16;
+        sample++;
+        count --;
+    }
+}
+

--- a/mupen64plus-rsp-hle/src/alist.h
+++ b/mupen64plus-rsp-hle/src/alist.h
@@ -42,6 +42,13 @@ void alist_repeat64(struct hle_t* hle, uint16_t dmemo, uint16_t dmemi, uint8_t c
 void alist_copy_blocks(struct hle_t* hle, uint16_t dmemo, uint16_t dmemi, uint16_t block_size, uint8_t count);
 void alist_interleave(struct hle_t* hle, uint16_t dmemo, uint16_t left, uint16_t right, uint16_t count);
 
+void alist_overload(
+        struct hle_t* hle,
+        uint16_t dmem,
+        int16_t count,
+        int16_t gain,
+        int16_t attenuation);
+
 void alist_envmix_exp(
         struct hle_t* hle,
         bool init,

--- a/mupen64plus-rsp-hle/src/alist_naudio.c
+++ b/mupen64plus-rsp-hle/src/alist_naudio.c
@@ -255,6 +255,16 @@ static void MP3ADDY(struct hle_t* UNUSED(hle), uint32_t UNUSED(w1), uint32_t UNU
 {
 }
 
+static void OVERLOAD(struct hle_t* hle, uint32_t w1, uint32_t w2)
+{
+    /* Overload distortion effect for Conker's Bad Fur Day */
+    uint16_t dmem = (w1 & 0xfff) + NAUDIO_MAIN;
+    int16_t gain = w2 & 0x7fff;
+    int16_t attenuation = w2 >> 16;
+
+    alist_overload(hle, dmem, NAUDIO_COUNT, gain, attenuation);
+}
+
 static void MP3(struct hle_t* hle, uint32_t w1, uint32_t w2)
 {
     unsigned index = (w1 & 0x1e);
@@ -322,7 +332,7 @@ void alist_process_naudio_cbfd(struct hle_t* hle)
 {
     /* TODO: see what differs from alist_process_naudio_mp3 */
     static const acmd_callback_t ABI[0x10] = {
-        UNKNOWN,        ADPCM,          CLEARBUFF,      ENVMIXER,
+        OVERLOAD,        ADPCM,          CLEARBUFF,      ENVMIXER,
         LOADBUFF,       RESAMPLE,       SAVEBUFF,       MP3,
         MP3ADDY,        SETVOL,         DMEMMOVE,       LOADADPCM,
         MIXER,          INTERLEAVE,     NAUDIO_14,      SETLOOP


### PR DESCRIPTION
https://github.com/mupen64plus/mupen64plus-rsp-hle/pull/84/files 

Needed for complete HLE emulation of CBFD.