### PR TITLE
Use Fiber backend on Win32.

### DIFF
--- a/libretro-common/libco/libco.c
+++ b/libretro-common/libco/libco.c
@@ -21,7 +21,9 @@ void genode_free_secondary_stack(void *stack);
     #include "fiber.c"
   #endif
 #elif defined __GNUC__
-  #if defined __i386__
+  #ifdef _WIN32
+    #include "fiber.c"
+  #elif defined __i386__
     #include "x86.c"
   #elif defined __amd64__
     #include "amd64.c"


### PR DESCRIPTION
Works around driver crashes on AMD Windows since driver seems to rely on unwinds to work properly.
libco cannot support this without using a more robust backend.