### PR TITLE
Makefile fix to enable cross build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ ifneq (,$(findstring unix,$(platform)))
    endif
 
    ifneq (,$(findstring armv,$(platform)))
+      ARCH = arm
+      WITH_DYNAREC = arm
       CPUFLAGS += -DARM -marm
       ifneq (,$(findstring cortexa8,$(platform)))
          CPUFLAGS += -mcpu=cortex-a8


### PR DESCRIPTION
"armv" platform is recognized by the makefile, but cross-compilation on an x86_64 host was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts), as ARCH was detected from host. Added fixed override.
