### PR TITLE
Add missing settings from the INI parser

### DIFF
--- a/custom/GLideN64/mupenplus/Config_mupenplus.cpp
+++ b/custom/GLideN64/mupenplus/Config_mupenplus.cpp
@@ -104,14 +104,20 @@ void LoadCustomSettings(bool internal)
 							config.frameBufferEmulation.N64DepthCompare = atoi(l.value);
 						}
 					}
+					else if (!strcmp(l.name, "frameBufferEmulation\\forceDepthBufferClear"))
+						config.frameBufferEmulation.forceDepthBufferClear = atoi(l.value);
 					else if (!strcmp(l.name, "frameBufferEmulation\\bufferSwapMode"))
 						config.frameBufferEmulation.bufferSwapMode = atoi(l.value);
 					else if (!strcmp(l.name, "texture\\bilinearMode"))
 						config.texture.bilinearMode = atoi(l.value);
+					else if (!strcmp(l.name, "texture\\enableHalosRemoval"))
+						config.texture.enableHalosRemoval = atoi(l.value);
 					else if (!strcmp(l.name, "texture\\maxAnisotropy"))
 						config.texture.maxAnisotropy = atoi(l.value);
 					else if (!strcmp(l.name, "graphics2D\\enableNativeResTexrects"))
 						config.graphics2D.enableNativeResTexrects = atoi(l.value);
+					else if (!strcmp(l.name, "graphics2D\\enableTexCoordBounds"))
+						config.graphics2D.enableTexCoordBounds = atoi(l.value);
 					// Inconsistent
 					else if (!strcmp(l.name, "generalEmulation\\correctTexrectCoords") || !strcmp(l.name, "graphics2D\\correctTexrectCoords"))
 						config.graphics2D.correctTexrectCoords = atoi(l.value);


### PR DESCRIPTION
> forceDepthBufferClear

Used for Eikou no Saint Andrews: https://github.com/libretro/mupen64plus-libretro-nx/blob/8d6ce5ea50f9bfe308ea3f5a4552acf9372cbbcd/GLideN64/ini/GLideN64.custom.ini#L26-L28

> enableHalosRemoval

Used for Pokemon Puzzle League: https://github.com/libretro/mupen64plus-libretro-nx/blob/8d6ce5ea50f9bfe308ea3f5a4552acf9372cbbcd/GLideN64/ini/GLideN64.custom.ini#L236-L238

> enableTexCoordBounds

Used for Mario Kart 64: https://github.com/libretro/mupen64plus-libretro-nx/blob/8d6ce5ea50f9bfe308ea3f5a4552acf9372cbbcd/GLideN64/ini/GLideN64.custom.ini#L154-L157

Ogre Battle 64 - Person of Lordly Caliber: https://github.com/libretro/mupen64plus-libretro-nx/blob/8d6ce5ea50f9bfe308ea3f5a4552acf9372cbbcd/GLideN64/ini/GLideN64.custom.ini#L195-L197

and Paper Mario: https://github.com/libretro/mupen64plus-libretro-nx/blob/8d6ce5ea50f9bfe308ea3f5a4552acf9372cbbcd/GLideN64/ini/GLideN64.custom.ini#L202-L205