### PR TITLE
Validate settings before applying

### DIFF
--- a/custom/GLideN64/mupenplus/Config_mupenplus.cpp
+++ b/custom/GLideN64/mupenplus/Config_mupenplus.cpp
@@ -225,4 +225,6 @@ extern "C" void Config_LoadConfig()
 		LoadCustomSettings(true);
 		LoadCustomSettings(false);
 	}
+
+	config.validate();
 }


### PR DESCRIPTION
Will run this existing function before applying settings: https://github.com/libretro/mupen64plus-libretro-nx/blob/29717c0b6e1be8c7b46dbd2801a275a72208ffea/GLideN64/src/Config.cpp#L155-L166

To avoid unwanted combination of settings, for example "Native res. 2D texrects" shouldn't be applied if "Native Resolution Factor" is set to "1x" since it's already running at native resolution.