### PR TITLE
"correctTexrectCoords" isn't inconsistent anymore

### DIFF
--- a/custom/GLideN64/mupenplus/Config_mupenplus.cpp
+++ b/custom/GLideN64/mupenplus/Config_mupenplus.cpp
@@ -118,8 +118,7 @@ void LoadCustomSettings(bool internal)
 						config.graphics2D.enableNativeResTexrects = atoi(l.value);
 					else if (!strcmp(l.name, "graphics2D\\enableTexCoordBounds"))
 						config.graphics2D.enableTexCoordBounds = atoi(l.value);
-					// Inconsistent
-					else if (!strcmp(l.name, "generalEmulation\\correctTexrectCoords") || !strcmp(l.name, "graphics2D\\correctTexrectCoords"))
+					else if (!strcmp(l.name, "graphics2D\\correctTexrectCoords"))
 						config.graphics2D.correctTexrectCoords = atoi(l.value);
 					else if (!strcmp(l.name, "generalEmulation\\enableLegacyBlending"))
 						config.generalEmulation.enableLegacyBlending = atoi(l.value);


### PR DESCRIPTION
Tetrisphere used to have `generalEmulation\correctTexrectCoords=2` in "GLideN64.custom.ini" which was incorrect, it was fixed a while ago (https://github.com/gonetz/GLideN64/pull/2702) and it now uses the proper `graphics2D\correctTexrectCoords=2` instead, since the .ini is now up-to-date on this repo we can remove that "inconsistent" part from the parser :)