### PR TITLE
Clean up properly on deinit to allow reinitialization

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -739,6 +739,10 @@ void retro_deinit(void)
        }
     }
 
+    CoreDoCommand(M64CMD_ROM_CLOSE, 0, NULL);
+
+    CoreShutdown();
+
     deinit_audio_libretro();
 
     if (perf_cb.perf_log)
@@ -1951,8 +1955,6 @@ void retro_unload_game(void)
        environ_clear_thread_waits_cb(1, NULL);
     }
 
-    CoreDoCommand(M64CMD_ROM_CLOSE, 0, NULL);
-
     if(current_rdp_type == RDP_PLUGIN_GLIDEN64 && EnableThreadedRenderer)
     {
        CoreDoCommand(M64CMD_STOP, 0, NULL);
@@ -1969,6 +1971,8 @@ void retro_unload_game(void)
 
        environ_clear_thread_waits_cb(0, NULL);
     }
+
+    CoreDoCommand(M64CMD_ROM_CLOSE, 0, NULL);
 
     cleanup_global_paths();
     


### PR DESCRIPTION
The two global variables we care about cleaning up properly, that are not currently, are `l_CoreInit` (only reset by `CoreShutdown`, which was not previously called from anywhere) and `l_ROMOpen`. `l_ROMOpen` is interesting because it is reset by `M64CMD_ROM_CLOSE` which is called from `retro_unload_game`; but sadly this is too early for it to be called, as `g_EmulatorRunning` is still `1`. So instead we have to wait for the emulator to have been stopped by `M64CMD_STOP`. Further, if the `current_rdp_type` is not `RDP_PLUGIN_GLIDEN64`, `M64CMD_ROM_CLOSE` is not invoked until `retro_deinit`.