### PR TITLE
Resolve GCC-13 compatibility

### DIFF
--- a/mupen64plus-video-angrylion/parallel_al.cpp
+++ b/mupen64plus-video-angrylion/parallel_al.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <functional>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 


### PR DESCRIPTION
Tested build on gcc (GCC) 13.1.1 20230429 on x86_64 Linux. Both additions were required to get a successful build.