### PR TITLE
Fix loading roms larger than 64MB

### DIFF
--- a/mupen64plus-core/src/device/cart/cart_rom.c
+++ b/mupen64plus-core/src/device/cart/cart_rom.c
@@ -32,7 +32,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define CART_ROM_ADDR_MASK UINT32_C(0x03ffffff);
+#define CART_ROM_ADDR_MASK UINT32_C(0x0fffffff);
 
 
 void init_cart_rom(struct cart_rom* cart_rom,


### PR DESCRIPTION
This one character fix makes the core able to load roms that are larger than 64MB in size. For example Super Mario 64 romhacks made using the older tools can sometimes surpass 64MB, and mupen64plus_next isn't able to run them correctly without this fix.