### PR TITLE
Modern G++ now needs stdexcept

### DIFF
--- a/mupen64plus-video-angrylion/parallel_al.cpp
+++ b/mupen64plus-video-angrylion/parallel_al.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <condition_variable>
 #include <cstdint>
+#include <stdexcept>
 #include <functional>
 #include <mutex>
 #include <thread>


### PR DESCRIPTION
Fixes compiling on newest GCC under MSYS2.