### PR TITLE
Add a button to quickly swap between Memory<->Rumble Paks

### DIFF
--- a/custom/mupen64plus-core/plugin/emulate_game_controller_via_libretro.c
+++ b/custom/mupen64plus-core/plugin/emulate_game_controller_via_libretro.c
@@ -86,6 +86,7 @@ static void inputGetKeys_default_descriptor(void)
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,      "C-Up" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     "Z Trigger" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,     "R Shoulder" },\
+      { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,     "Memory/Rumble Pak Swap" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "L Shoulder" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Start" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "D-Pad Right" },\
@@ -117,6 +118,7 @@ static void inputGetKeys_default_descriptor(void)
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     "Z Trigger" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      "R Shoulder" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      "L Shoulder" },\
+      { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Memory/Rumble Pak Swap" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Start" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "D-Pad Right" },\
       { PAD, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   "D-Pad Left" },\

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1656,6 +1656,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
             {"memory", NULL},
             {"rumble", NULL},
             {"transfer", NULL},
+            {"memory/rumble (swappable)", NULL},
             { NULL, NULL },
         },
         "memory"
@@ -1672,6 +1673,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
             {"memory", NULL},
             {"rumble", NULL},
             {"transfer", NULL},
+            {"memory/rumble (swappable)", NULL},
             { NULL, NULL },
         },
         "none"
@@ -1688,6 +1690,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
             {"memory", NULL},
             {"rumble", NULL},
             {"transfer", NULL},
+            {"memory/rumble (swappable)", NULL},
             { NULL, NULL },
         },
         "none"
@@ -1704,9 +1707,26 @@ struct retro_core_option_v2_definition option_defs_us[] = {
             {"memory", NULL},
             {"rumble", NULL},
             {"transfer", NULL},
+            {"memory/rumble (swappable)", NULL},
             { NULL, NULL },
         },
         "none"
+    },
+    {
+        CORE_NAME "-pak-swap-delay",
+        "Memory/Rumble Pak Swap Hold Delay",
+        NULL,
+        "Select how long you have to hold the 'Memory/Rumble Pak Swap' button to perform the swap between the Memory Pak and the Rumble Pak. NOTE: only works if the player's Pak is set to 'memory/rumble (swappable)'",
+        NULL,
+        "input",
+        {
+            {"0", "0 second"},
+            {"1", "1 second"},
+            {"2", "2 seconds"},
+            {"3", "3 seconds"},
+            { NULL, NULL },
+        },
+        "0"
     },
     { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
 };


### PR DESCRIPTION
This PR adds a button to quickly swap from Memory Pak to Rumble Pak and vice-versa (RetroPad Select by default, or R3 if "Independent C-button Controls" is enabled):

https://github.com/libretro/mupen64plus-libretro-nx/assets/33353403/440b6d40-2350-4e46-b305-ae9f636e9569

Very useful for games compatible with both Paks, going back and forth in the Quick Menu every time you want to change quickly becomes annoying...

Just select "memory/rumble (swappable)" for any of the "Player N Pak" core options and it will be enabled for that controller. Also added a core option to select if the swap should be done on press or on hold (1, 2 or 3 seconds).

I hope this is fine, if it is then it closes #502

Also removed the `update_controllers()` call here: https://github.com/libretro/mupen64plus-libretro-nx/blob/f1ad37c3a9be64b499d9a36f57e41d59fb677c73/libretro/libretro.c#L1988-L1991 since it's already done at the end of `update_variables()` just above.