### PR TITLE
parallel rdp/rsp on iOS and tvOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,8 @@ else ifneq (,$(findstring ios,$(platform)))
    DEFINES += -DIOS
    GLES = 1
 	ifeq ($(platform),ios-arm64)
+		HAVE_PARALLEL_RSP = 1
+		HAVE_PARALLEL_RDP = 1
 		WITH_DYNAREC=
 		GLES=1
 		GLES3=1
@@ -474,6 +476,7 @@ else ifneq (,$(findstring tvos,$(platform)))
    GLES3=1
    FORCE_GLES3=1
    EGL := 0
+   HAVE_PARALLEL_RSP = 1
    HAVE_PARALLEL_RDP = 1
    PLATCFLAGS += -DHAVE_POSIX_MEMALIGN -DNO_ASM
    PLATCFLAGS += -DIOS -DTVOS -marm -DOS_IOS -DOS_TVOS -DDONT_WANT_ARM_OPTIMIZATIONS

--- a/Makefile.common
+++ b/Makefile.common
@@ -483,6 +483,8 @@ endif
 
 ifneq ($(platform), $(filter $(platform), ios-arm64 tvos-arm64))
 	EGL_LIB ?= -lEGL
+else
+	SOURCES_C += $(ROOT_DIR)/custom/ios/compat.c
 endif
 
 ifeq ($(GLES3),1)

--- a/custom/ios/compat.c
+++ b/custom/ios/compat.c
@@ -1,0 +1,8 @@
+#include <libkern/OSCacheControl.h>
+
+void __clear_cache(void *start, void *end)
+{
+    size_t len = (char*)end - (char*)start;
+    sys_dcache_flush(start, len);
+    sys_icache_invalidate(start, len);
+}

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -911,6 +911,24 @@ static void update_variables(bool startup)
           }
        }
        
+#ifdef IOS
+       bool can_jit = false;
+       if (!environ_cb(RETRO_ENVIRONMENT_GET_JIT_CAPABLE, &can_jit) || !can_jit)
+       {
+          if(current_rsp_type == RSP_PLUGIN_PARALLEL)
+          {
+#if defined(HAVE_LLE)
+             plugin_connect_rsp_api(RSP_PLUGIN_CXD4);
+             log_cb(RETRO_LOG_INFO, "Selected Parallel RSP without JIT, falling back to CXD4!\n");
+#else
+             log_cb(RETRO_LOG_INFO, "Selected Parallel RSP without JIT, falling back to GLideN64!\n");
+             plugin_connect_rsp_api(RSP_PLUGIN_HLE);
+             plugin_connect_rdp_api(RDP_PLUGIN_GLIDEN64);
+#endif
+          }
+       }
+#endif
+
        var.key = CORE_NAME "-ThreadedRenderer";
        var.value = NULL;
        if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)


### PR DESCRIPTION
This is exactly the same as the last PR except that now instead of temporarily pointing at my parallel-rsp fork, it points at libretro/parallel-rsp (formerly known as themaister/parallel-rsp).

This comes in four commits, to hopefully make it easier to see what the changes were:
1. Changing the parallel-rsp subrepo to libretro/parallel-rsp
2. git subrepo pull mupen64plus-rsp-paraLLEl, to pull in the latest version
3. Fix the build with the new lightning JIT from the new parallel-rsp
4. The iOS/tvOS specific changes to turn on the parallel rdp/rsp plugins.