### PR TITLE
Add emscripten support built against patched 2.0.34 emsdk

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilderCommon.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilderCommon.cpp
@@ -37,7 +37,11 @@ public:
 		}
 		else if (_glinfo.isGLESX) {
 			std::stringstream ss;
+#ifdef EMSCRIPTEN
+			ss << "#version 300 es " << std::endl;
+#else
 			ss << "#version " << Utils::to_string(_glinfo.majorVersion) << Utils::to_string(_glinfo.minorVersion) << "0 es " << std::endl;
+#endif
 			ss << "# define IN in" << std::endl << "# define OUT out" << std::endl;
 			if (_glinfo.noPerspective) {
 				ss << "#extension GL_NV_shader_noperspective_interpolation : enable" << std::endl
@@ -208,7 +212,11 @@ public:
 			;
 		} else if (_glinfo.isGLESX) {
 			std::stringstream ss;
+#ifdef EMSCRIPTEN
+			ss << "#version 300 es " << std::endl;
+#else
 			ss << "#version " << Utils::to_string(_glinfo.majorVersion) << Utils::to_string(_glinfo.minorVersion) << "0 es " << std::endl;
+#endif
 			if (_glinfo.noPerspective)
 				ss << "#extension GL_NV_shader_noperspective_interpolation : enable" << std::endl;
 			if (_glinfo.dual_source_blending)

--- a/GLideN64/src/Graphics/OpenGLContext/ThreadedOpenGl/atomicops.h
+++ b/GLideN64/src/Graphics/OpenGLContext/ThreadedOpenGl/atomicops.h
@@ -530,6 +530,9 @@ namespace moodycamel
 
 			bool timed_wait(std::uint64_t usecs) AE_NO_TSAN
 			{
+#if defined(EMSCRIPTEN) && !defined(__EMSCRIPTEN_PTHREADS__)
+				return try_wait();
+#else
 				struct timespec ts;
 				const int usecs_in_1_sec = 1000000;
 				const int nsecs_in_1_sec = 1000000000;
@@ -548,6 +551,7 @@ namespace moodycamel
 					rc = sem_timedwait(&m_sema, &ts);
 				} while (rc == -1 && errno == EINTR);
 				return !(rc == -1 && errno == ETIMEDOUT);
+#endif
 			}
 
 			void signal() AE_NO_TSAN

--- a/GLideN64/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.cpp
@@ -8,7 +8,7 @@ extern "C" {
 	extern void context_reset();
 	bool threaded_gl_safe_shutdown = false;
 
-	void gln64_thr_gl_invoke_command_loop()
+	void gln64_thr_gl_invoke_command_loop(void)
 	{
 		opengl::FunctionWrapper::commandLoop();
 	}

--- a/GLideN64/src/xxHash/xxhash.h
+++ b/GLideN64/src/xxHash/xxhash.h
@@ -2284,7 +2284,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 #endif
 
 
-#if XXH_VECTOR == XXH_NEON
+#if (XXH_VECTOR == XXH_NEON) && !defined(EMSCRIPTEN)
 /*
  * NEON's setup for vmlal_u32 is a little more complicated than it is on
  * SSE2, AVX2, and VSX.
@@ -3338,7 +3338,7 @@ XXH_FORCE_INLINE XXH_TARGET_SSE2 void XXH3_initCustomSecret_sse2(void* XXH_RESTR
 
 #endif
 
-#if (XXH_VECTOR == XXH_NEON)
+#if (XXH_VECTOR == XXH_NEON) && !defined(EMSCRIPTEN)
 
 XXH_FORCE_INLINE void
 XXH3_accumulate_512_neon( void* XXH_RESTRICT acc,
@@ -3622,7 +3622,7 @@ typedef void (*XXH3_f_initCustomSecret)(void* XXH_RESTRICT, xxh_u64);
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_sse2
 #define XXH3_initCustomSecret XXH3_initCustomSecret_sse2
 
-#elif (XXH_VECTOR == XXH_NEON)
+#elif (XXH_VECTOR == XXH_NEON) && !defined(EMSCRIPTEN)
 
 #define XXH3_accumulate_512 XXH3_accumulate_512_neon
 #define XXH3_scrambleAcc    XXH3_scrambleAcc_neon

--- a/custom/dependencies/libzlib/gzguts.h
+++ b/custom/dependencies/libzlib/gzguts.h
@@ -27,6 +27,11 @@
 #endif
 #include <fcntl.h>
 
+/* TODO: Do other platforms need this? */
+#ifdef EMSCRIPTEN
+#  include <unistd.h>
+#endif
+
 #ifdef _WIN32
 #  include <stddef.h>
 #endif

--- a/custom/mupen64plus-next_common.h
+++ b/custom/mupen64plus-next_common.h
@@ -79,7 +79,7 @@ extern char* retro_transferpak_rom_path;
 extern char* retro_transferpak_ram_path;
 
 // Threaded GL Callback
-extern void gln64_thr_gl_invoke_command_loop();
+extern void gln64_thr_gl_invoke_command_loop(void);
 extern bool threaded_gl_safe_shutdown;
 
 // Core options

--- a/libretro-common/glsm/glsm.c
+++ b/libretro-common/glsm/glsm.c
@@ -27,6 +27,10 @@
 #include <glsm/glsm.h>
 #include <mupen64plus-next_common.h>
 
+#ifdef NOCOMMON
+#include <libretro_private.h>
+#endif
+
 #if defined(HAVE_OPENGLES)
 #if !defined(IOS)
 #include <EGL/egl.h>

--- a/libretro-common/libco/emscripten_fiber.c
+++ b/libretro-common/libco/emscripten_fiber.c
@@ -1,0 +1,64 @@
+/*
+  libco.emscripten (2020-02-27)
+  authors: Toad King
+  license: public domain
+*/
+
+#define LIBCO_C
+#include <libco.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <malloc.h>
+#include <emscripten/fiber.h>
+
+#define ASYNCIFY_STACK_SIZE (131072)
+
+static thread_local emscripten_fiber_t *co_active_;
+
+static void co_thunk(void *coentry)
+{
+   ((void (*)(void))coentry)();
+}
+
+static void co_init(void)
+{
+   if (!co_active_)
+   {
+      emscripten_fiber_t *co_primary = calloc(1, sizeof(emscripten_fiber_t));
+      void *asyncify_stack = malloc(ASYNCIFY_STACK_SIZE);
+
+      emscripten_fiber_init_from_current_context(co_primary, asyncify_stack, ASYNCIFY_STACK_SIZE);
+      co_active_ = co_primary;
+   }
+}
+
+cothread_t co_active(void)
+{
+   co_init();
+   return co_active_;
+}
+
+cothread_t co_create(unsigned int stacksize, void (*coentry)(void))
+{
+   co_init();
+
+   emscripten_fiber_t *fiber = calloc(1, sizeof(emscripten_fiber_t));
+   void *asyncify_stack = malloc(ASYNCIFY_STACK_SIZE);
+   void *c_stack = memalign(16, stacksize);
+   emscripten_fiber_init(fiber, co_thunk, coentry, c_stack, stacksize, asyncify_stack, ASYNCIFY_STACK_SIZE);
+
+   return (cothread_t)fiber;
+}
+
+void co_delete(cothread_t cothread)
+{
+   free(cothread);
+}
+
+void co_switch(cothread_t cothread)
+{
+   emscripten_fiber_t *old_fiber = co_active_;
+   co_active_ = (emscripten_fiber_t *)cothread;
+
+   emscripten_fiber_swap(old_fiber, co_active_);
+}

--- a/libretro-common/libco/libco.c
+++ b/libretro-common/libco/libco.c
@@ -9,7 +9,9 @@ void *genode_alloc_secondary_stack(unsigned long stack_size);
 void genode_free_secondary_stack(void *stack);
 #endif
 
-#if defined _MSC_VER
+#ifdef EMSCRIPTEN
+  #include "emscripten_fiber.c"
+#elif defined _MSC_VER
   #include <Windows.h>
   #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
     #include "fiber.c"

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -441,7 +441,11 @@ static void emu_step_initialize(void)
     plugin_connect_all();
 }
 
+#ifdef EMSCRIPTEN
+static void EmuThreadFunction(void)
+#else
 static void* EmuThreadFunction(void* param)
+#endif
 {
     uint32_t netplay_port = 0;
     uint16_t netplay_player = 1;
@@ -485,7 +489,11 @@ static void* EmuThreadFunction(void* param)
         emuThreadRunning = false;
     }
 
+#ifdef EMSCRIPTEN
+    return;
+#else
     return NULL;
+#endif
 }
 
 static void reinit_gfx_plugin(void)

--- a/mupen64plus-core/src/backends/file_storage.c
+++ b/mupen64plus-core/src/backends/file_storage.c
@@ -33,6 +33,10 @@
 #include <libretro_private.h>
 #include <mupen64plus-next_common.h>
 
+#ifdef NOCOMMON
+#include <libretro_private.h>
+#endif
+
 int open_file_storage(struct file_storage* fstorage, size_t size, const char* filename)
 {
     /* ! Take ownership of filename ! */


### PR DESCRIPTION
This is an update of toadkings PR here and I cannot take credit for these changes https://github.com/BinBashBanana using toadkings old PR got this all working: 
https://github.com/libretro/mupen64plus-libretro-nx/pull/132

This needs to be built against a specific version of emscripten that has webgl patched.
```
git clone https://github.com/emscripten-core/emsdk.git
cd emsdk
./emsdk install 2.0.34
./emsdk activate 2.0.34
wget https://raw.githubusercontent.com/BinBashBanana/webretro/master/source/patches/emscripten.patch
patch -u -p0 -i emscripten.patch
source emsdk_env.sh
```

On the retroarch side should be built without ASYNC flagged as is currently defined here: (can be deleted)
https://github.com/libretro/RetroArch/blob/master/Makefile.emscripten#L61C1-L63C6

And with the additional flags: 
`-s TOTAL_STACK=268435456 -s TOTAL_MEMORY=536870912 -s FULL_ES3=1 -s MIN_WEBGL_VERSION=2 -s MAX_WEBGL_VERSION=2`

The results are very good even on a low end client machine: 

https://github.com/libretro/mupen64plus-libretro-nx/assets/1852688/a0feb40d-acba-4281-a887-cb7cdcfc0c2f

I can rewrite the guards Retroarch side as well but having a viable bc file is the first step. 

Let me know if this is possible to mainline I do not have a deep enough understanding of the codebase to see if there are any breaking changes for other ports here, but most of it looks non obtrusive with guards. 