### PR TITLE
Add support for RPi5 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,16 @@ else ifneq (,$(findstring rpi,$(platform)))
          CPUFLAGS += -march=armv8-a+crc -mtune=cortex-a72
          ARM_CPUFLAGS = -mfpu=neon-fp-armv8
       endif
+   else ifneq (,$(findstring rpi5,$(platform)))
+      ifneq (,$(findstring rpi5_64,$(platform)))
+         CPUFLAGS += -mcpu=cortex-a76 -mtune=cortex-a76
+      else
+         CPUFLAGS += -march=armv8-a+crc+crypto -mtune=cortex-a76
+         ARM_CPUFLAGS = -mfpu=neon-fp-armv8
+      endif
+      HAVE_PARALLEL_RSP = 1
+      HAVE_THR_AL = 1
+      LLE = 1
    else ifneq (,$(findstring rpi,$(platform)))
       CPUFLAGS += -mcpu=arm1176jzf-s
       ARM_CPUFLAGS = -mfpu=vfp


### PR DESCRIPTION
Hi! This adds support for building on RPi5. I have been using it with the angrylion plugin and the performance is great. Also I have tested it with the parallel RSP and cxd4 RSP and they both work fine.