### PR TITLE
Parallel RSP pagesize at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ ifeq (,$(ARCH))
    ARCH = $(shell uname -m)
 endif
 
+ifeq ($(shell uname -m),aarch64)
+   CPUFLAGS += -DPAGESIZE=$(or $(shell getconf PAGESIZE),4096)
+endif
+
 # Target Dynarec
 WITH_DYNAREC ?= $(ARCH)
 

--- a/mupen64plus-rsp-paraLLEl/jit_allocator.cpp
+++ b/mupen64plus-rsp-paraLLEl/jit_allocator.cpp
@@ -38,6 +38,8 @@ static size_t align_page(size_t offset)
 {
 #if defined(__APPLE__) && defined(__aarch64__)
 	size_t pagesize = sysconf(_SC_PAGESIZE) - 1;
+#elif defined(PAGESIZE)
+	size_t pagesize = PAGESIZE - 1;
 #else
 	size_t pagesize = 4095;
 #endif


### PR DESCRIPTION
This adds support for defining pagesize at buildtime for parallel RSP. Relevant issues on RPi5 from other libretro cores.

https://github.com/flyinghead/flycast/issues/1288
https://github.com/realnc/dosbox-core/issues/57
https://github.com/schellingb/dosbox-pure/issues/488