### PR TITLE
Upload audio once per frame

### DIFF
--- a/custom/mupen64plus-core/plugin/audio_libretro/audio_backend_libretro.c
+++ b/custom/mupen64plus-core/plugin/audio_libretro/audio_backend_libretro.c
@@ -41,6 +41,7 @@
 #include <audio/audio_resampler.h>
 
 extern void retro_audio_queue(const int16_t *data, int32_t samples);
+extern void retro_set_system_av_info(unsigned GameFreq);
 
 static unsigned MAX_AUDIO_FRAMES = 2048;
 
@@ -97,6 +98,7 @@ static void aiDacrateChanged(void *user_data, unsigned int frequency)
    CountsPerSecond = VI_INTR_TIME * 60 /* TODO/FIXME - dehardcode */;
    CountsPerByte   = CountsPerSecond / BytesPerSecond;
 
+   retro_set_system_av_info(GameFreq);
 #if 0
    printf("CountsPerByte: %d, GameFreq: %d\n", CountsPerByte, GameFreq);
 #endif

--- a/custom/mupen64plus-core/plugin/audio_libretro/audio_backend_libretro.c
+++ b/custom/mupen64plus-core/plugin/audio_libretro/audio_backend_libretro.c
@@ -40,7 +40,7 @@
 #include <audio/conversion/s16_to_float.h>
 #include <audio/audio_resampler.h>
 
-extern retro_audio_sample_batch_t audio_batch_cb;
+extern void retro_audio_queue(const int16_t *data, int32_t samples);
 
 static unsigned MAX_AUDIO_FRAMES = 2048;
 
@@ -162,14 +162,10 @@ audio_batch:
    resampler->process(resampler_audio_data, &data);
    convert_float_to_s16(audio_out_buffer_s16, audio_out_buffer_float, data.output_frames * 2);
 
-   out                    = audio_out_buffer_s16;
+   out               = audio_out_buffer_s16;
 
-   while (data.output_frames)
-   {
-      size_t ret          = audio_batch_cb(out, data.output_frames);
-      data.output_frames -= ret;
-      out                += ret * 2;
-   }
+   retro_audio_queue(out, data.output_frames * 2);
+
    if (remain_frames)
    {
       raw_data = raw_data + frames * 2;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -18,6 +18,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifdef __MINGW32__
+#define _CRT_RAND_S
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -73,6 +73,8 @@
 
 #define PATH_SIZE 2048
 
+#define SAMPLE_RATE 44100
+
 #define ISHEXDEC ((codeLine[cursor]>='0') && (codeLine[cursor]<='9')) || ((codeLine[cursor]>='a') && (codeLine[cursor]<='f')) || ((codeLine[cursor]>='A') && (codeLine[cursor]<='F'))
 
 /* Forward declarations */
@@ -141,7 +143,7 @@ static bool     load_game_successful = false;
 
 static bool     context_setup_first_init = false;
 
-bool libretro_swap_buffer;
+bool libretro_swap_buffer = false;
 
 uint32_t *blitter_buf = NULL;
 uint32_t *blitter_buf_lock = NULL;
@@ -150,6 +152,7 @@ uint32_t retro_screen_height = 480;
 uint32_t screen_pitch = 0;
 
 float retro_screen_aspect = 4.0 / 3.0;
+float retro_fps = 60;
 
 static char rdp_plugin_last[32] = {0};
 
@@ -725,8 +728,8 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
     if (current_rdp_type == RDP_PLUGIN_PARALLEL)
         parallel_get_geometry(&info->geometry);
 #endif
-    info->timing.sample_rate = 44100.0;
-    info->timing.fps = (ROM_PARAMS.systemtype == SYSTEM_PAL) ? 50.00f : 59.94f;
+    info->timing.sample_rate = SAMPLE_RATE;
+    info->timing.fps = (ROM_PARAMS.systemtype == SYSTEM_PAL) ? 50 : 60;
 }
 
 void retro_set_system_av_info(unsigned GameFreq)
@@ -760,6 +763,10 @@ void retro_set_system_av_info(unsigned GameFreq)
          break;
    }
 
+   if (retro_fps == system_av_info.timing.fps)
+      return;
+
+   retro_fps = system_av_info.timing.fps;
    environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &system_av_info);
 }
 
@@ -2016,7 +2023,7 @@ bool retro_load_game(const struct retro_game_info *game)
     }
  
     // Init default vals
-    retro_savestate_complete = true;
+    retro_savestate_complete = false;
     load_game_successful = false;
 
     glsm_ctx_params_t params = {0};
@@ -2114,10 +2121,52 @@ void retro_unload_game(void)
     retro_savestate_complete = false;
 }
 
+void retro_swap_video_buffers()
+{
+    if (libretro_swap_buffer)
+    {
+        if (current_rdp_type == RDP_PLUGIN_GLIDEN64)
+        {
+            video_cb(RETRO_HW_FRAME_BUFFER_VALID, retro_screen_width, retro_screen_height, 0);
+        }
+#ifdef HAVE_THR_AL
+        else if (current_rdp_type == RDP_PLUGIN_ANGRYLION)
+        {
+            video_cb(prescale, retro_screen_width, retro_screen_height, screen_pitch);
+        }
+#endif
+#ifdef HAVE_PARALLEL_RDP
+        else if (current_rdp_type == RDP_PLUGIN_PARALLEL)
+        {
+            parallel_profile_video_refresh_begin();
+            video_cb(parallel_frame_is_valid() ? RETRO_HW_FRAME_BUFFER_VALID : NULL,
+                    parallel_frame_width(), parallel_frame_height(), 0);
+            parallel_profile_video_refresh_end();
+        }
+#endif
+    }
+    else if (EnableFrameDuping)
+    {
+        // screen_pitch will be 0 for GLN
+        video_cb(NULL, retro_screen_width, retro_screen_height, screen_pitch);
+    }
+
+    upload_output_audio_buffer();
+}
+
 void retro_run (void)
 {
-    libretro_swap_buffer = false;
     static bool updated = false;
+
+    if (retro_savestate_complete == true && libretro_swap_buffer == true)
+    {
+       // Swap buffers fast pass, defering after a savestate if a frame was produced while unsafe interrupt
+       retro_swap_video_buffers();
+       retro_savestate_complete = false;
+       return;
+    }
+
+    libretro_swap_buffer = false;
 
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated) {
        update_variables(false);
@@ -2145,35 +2194,7 @@ void retro_run (void)
        glsm_ctl(GLSM_CTL_STATE_UNBIND, NULL);
     }
     
-    if (libretro_swap_buffer)
-    {
-       if(current_rdp_type == RDP_PLUGIN_GLIDEN64)
-       {
-          video_cb(RETRO_HW_FRAME_BUFFER_VALID, retro_screen_width, retro_screen_height, 0);
-       }
-#ifdef HAVE_THR_AL
-       else if(current_rdp_type == RDP_PLUGIN_ANGRYLION)
-       {
-          video_cb(prescale, retro_screen_width, retro_screen_height, screen_pitch);
-       }
-#endif // HAVE_THR_AL
-#ifdef HAVE_PARALLEL_RDP
-       else if (current_rdp_type == RDP_PLUGIN_PARALLEL)
-       {
-           parallel_profile_video_refresh_begin();
-           video_cb(parallel_frame_is_valid() ? RETRO_HW_FRAME_BUFFER_VALID : NULL,
-                   parallel_frame_width(), parallel_frame_height(), 0);
-           parallel_profile_video_refresh_end();
-       }
-#endif
-    }
-    else if(EnableFrameDuping)
-    {
-        // screen_pitch will be 0 for GLN
-        video_cb(NULL, retro_screen_width, retro_screen_height, screen_pitch);
-    }
-
-    upload_output_audio_buffer();
+    retro_swap_video_buffers();
 }
 
 void retro_reset (void)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -266,6 +266,8 @@ static void free_output_audio_buffer()
 
 static void upload_output_audio_buffer()
 {
+   if (!output_audio_buffer.size)
+      return;
    audio_batch_cb(output_audio_buffer.data, output_audio_buffer.size / 2);
    output_audio_buffer.size = 0;
 }
@@ -724,9 +726,41 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
         parallel_get_geometry(&info->geometry);
 #endif
     info->timing.sample_rate = 44100.0;
-    info->timing.fps = (ROM_PARAMS.systemtype == SYSTEM_PAL)
-          ? info->timing.sample_rate / 882
-          : info->timing.sample_rate / 736;
+    info->timing.fps = (ROM_PARAMS.systemtype == SYSTEM_PAL) ? 50.00f : 59.94f;
+}
+
+void retro_set_system_av_info(unsigned GameFreq)
+{
+   struct retro_system_av_info system_av_info;
+   retro_get_system_av_info(&system_av_info);
+
+   if (ROM_PARAMS.systemtype == SYSTEM_PAL)
+      system_av_info.timing.fps = 50.00f;
+   else
+   switch (GameFreq)
+   {
+      case 21998:
+         system_av_info.timing.fps = 59.78f;
+         break;
+      case 44095:
+      case 22047:
+         system_av_info.timing.fps = 59.82f;
+         break;
+      case 22496:
+         system_av_info.timing.fps = 59.88f;
+         break;
+      case 26807:
+         system_av_info.timing.fps = 59.90f;
+         break;
+      case 32006:
+         system_av_info.timing.fps = 59.98f;
+         break;
+      default:
+         system_av_info.timing.fps = 59.94f;
+         break;
+   }
+
+   environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &system_av_info);
 }
 
 unsigned retro_get_region (void)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -226,6 +226,57 @@ extern struct cheat_ctx g_cheat_ctx;
 static bool emuThreadRunning = false;
 static pthread_t emuThread;
 
+/* Audio output buffer */
+static struct {
+   int16_t *data;
+   int32_t size;
+   int32_t capacity;
+} output_audio_buffer = {NULL, 0, 0};
+
+static void ensure_output_audio_buffer_capacity(int32_t capacity)
+{
+   if (capacity <= output_audio_buffer.capacity) {
+      return;
+   }
+
+   output_audio_buffer.data = realloc(output_audio_buffer.data, capacity * sizeof(*output_audio_buffer.data));
+   output_audio_buffer.capacity = capacity;
+   log_cb(RETRO_LOG_DEBUG, "Output audio buffer capacity set to %d\n", capacity);
+}
+
+static void init_output_audio_buffer(int32_t capacity)
+{
+   output_audio_buffer.data = NULL;
+   output_audio_buffer.size = 0;
+   output_audio_buffer.capacity = 0;
+   ensure_output_audio_buffer_capacity(capacity);
+}
+
+static void free_output_audio_buffer()
+{
+   free(output_audio_buffer.data);
+   output_audio_buffer.data = NULL;
+   output_audio_buffer.size = 0;
+   output_audio_buffer.capacity = 0;
+}
+
+static void upload_output_audio_buffer()
+{
+   audio_batch_cb(output_audio_buffer.data, output_audio_buffer.size / 2);
+   output_audio_buffer.size = 0;
+}
+
+void retro_audio_queue(const int16_t *data, int32_t samples)
+{
+   if ((samples < 1) || !emu_initialized)
+      return;
+
+   if (output_audio_buffer.capacity - output_audio_buffer.size < samples)
+      ensure_output_audio_buffer_capacity((output_audio_buffer.capacity + samples) * 1.5);
+   memcpy(output_audio_buffer.data + output_audio_buffer.size, data, samples * sizeof(*output_audio_buffer.data));
+   output_audio_buffer.size += samples;
+}
+
 // after the controller's CONTROL* member has been assigned we can update
 // them straight from here...
 extern struct
@@ -668,8 +719,10 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
     if (current_rdp_type == RDP_PLUGIN_PARALLEL)
         parallel_get_geometry(&info->geometry);
 #endif
-    info->timing.fps = vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype);
     info->timing.sample_rate = 44100.0;
+    info->timing.fps = (ROM_PARAMS.systemtype == SYSTEM_PAL)
+          ? info->timing.sample_rate / 882
+          : info->timing.sample_rate / 736;
 }
 
 unsigned retro_get_region (void)
@@ -728,6 +781,8 @@ void retro_init(void)
     m64p_error ret = CoreStartup(FRONTEND_API_VERSION, ".", ".", NULL, n64DebugCallback, 0, n64StateCallback);
     if(ret && log_cb)
         log_cb(RETRO_LOG_ERROR, CORE_NAME ": failed to initialize core (err=%i)\n", ret);
+
+    init_output_audio_buffer(2048);
 }
 
 void retro_deinit(void)
@@ -745,6 +800,7 @@ void retro_deinit(void)
 
     CoreShutdown();
     deinit_audio_libretro();
+    free_output_audio_buffer();
 
     if (perf_cb.perf_log)
         perf_cb.perf_log();
@@ -2078,6 +2134,8 @@ void retro_run (void)
         // screen_pitch will be 0 for GLN
         video_cb(NULL, retro_screen_width, retro_screen_height, screen_pitch);
     }
+
+    upload_output_audio_buffer();
 }
 
 void retro_reset (void)

--- a/mupen64plus-core/src/main/savestates.c
+++ b/mupen64plus-core/src/main/savestates.c
@@ -270,6 +270,7 @@ int savestates_load_m64p(struct device* dev, const void *data)
     if(strncmp((char *)curr, savestate_magic, 8)!=0)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Savestate is not a valid Mupen64plus savestate.");
+        pthread_mutex_unlock(&savestates_lock);
         return 0;
     }
 #endif


### PR DESCRIPTION
Copypasted the same solid code used in a few cores, so that audio is uploaded once per frame after video callback, and not twice in between.

