### PR TITLE
Parse "&" properly from GLideN64.custom.ini

### DIFF
--- a/custom/GLideN64/mupenplus/Config_mupenplus.cpp
+++ b/custom/GLideN64/mupenplus/Config_mupenplus.cpp
@@ -29,6 +29,10 @@ std::string replaceChars(std::string myString)
 	{
 		myString.replace(pos, 1, "%27");
 	}
+	for (size_t pos = myString.find('&'); pos != std::string::npos; pos = myString.find('&', pos))
+	{
+		myString.replace(pos, 1, "%26");
+	}
 	return myString;
 }
 


### PR DESCRIPTION
Needed for Pokemon Stadium Kin Gin, the internal name is `POKEMON STADIUM G&S` and the "&" is replaced with "%26" in the .ini: `[POKEMON%20STADIUM%20G%26S]`, so currently the game settings aren't applied, easy to check on the main menu:

* Currently:
  ![image](https://github.com/user-attachments/assets/02825406-af3d-484b-9349-87f392f4eb8a)
* With proper "&" parsing:
  ![image](https://github.com/user-attachments/assets/c1a2b000-68f9-4e51-adc2-d16bb2136ead)
