### PR TITLE
Add a "Enable color buffer copy from RDRAM" core option (EnableCopyColorFromRDRAM)

### DIFF
--- a/custom/GLideN64/mupenplus/Config_mupenplus.cpp
+++ b/custom/GLideN64/mupenplus/Config_mupenplus.cpp
@@ -164,6 +164,7 @@ extern "C" void Config_LoadConfig()
 	
 	config.frameBufferEmulation.copyDepthToRDRAM = EnableCopyDepthToRDRAM;
 	config.frameBufferEmulation.copyToRDRAM = EnableCopyColorToRDRAM;
+	config.frameBufferEmulation.copyFromRDRAM = EnableCopyColorFromRDRAM;
 
 	// TODO: Make this a Core options or maybe only default to bsOnVerticalInterrupt on Android with Thr Renderer
 	config.frameBufferEmulation.bufferSwapMode = Config::bsOnVerticalInterrupt;

--- a/custom/mupen64plus-next_common.h
+++ b/custom/mupen64plus-next_common.h
@@ -99,6 +99,7 @@ extern uint32_t EnableInaccurateTextureCoordinates;
 extern uint32_t enableNativeResTexrects;
 extern uint32_t enableLegacyBlending;
 extern uint32_t EnableCopyColorToRDRAM;
+extern uint32_t EnableCopyColorFromRDRAM;
 extern uint32_t EnableCopyDepthToRDRAM;
 extern uint32_t AspectRatio;
 extern uint32_t MaxTxCacheSize;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -175,6 +175,7 @@ uint32_t EnableInaccurateTextureCoordinates = 0;
 uint32_t enableNativeResTexrects = 0;
 uint32_t enableLegacyBlending = 0;
 uint32_t EnableCopyColorToRDRAM = 0;
+uint32_t EnableCopyColorFromRDRAM = 0;
 uint32_t EnableCopyDepthToRDRAM = 0;
 uint32_t AspectRatio = 0;
 uint32_t MaxTxCacheSize = 0;
@@ -1059,6 +1060,13 @@ static void update_variables(bool startup)
              EnableCopyColorToRDRAM = 1;
           else
              EnableCopyColorToRDRAM = 0;
+       }
+
+       var.key = CORE_NAME "-EnableCopyColorFromRDRAM";
+       var.value = NULL;
+       if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+       {
+          EnableCopyColorFromRDRAM = !strcmp(var.value, "False") ? 0 : 1;
        }
 
        var.key = CORE_NAME "-EnableCopyDepthToRDRAM";

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -360,6 +360,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
 #endif // HAVE_OPENGLES2
     },
     {
+        CORE_NAME "-EnableCopyColorFromRDRAM",
+        "Enable color buffer copy from RDRAM",
+        NULL,
+        NULL,
+        NULL,
+        "gliden64",
+        {
+            {"False", NULL},
+            {"True", NULL},
+            { NULL, NULL },
+        },
+        "False",
+    },
+    {
         CORE_NAME "-EnableCopyDepthToRDRAM",
         "Depth buffer to RDRAM",
         NULL,


### PR DESCRIPTION
Useful to make the cursor visible in Mario Artist - Paint Studio:

* Currently:
  ![image](https://github.com/user-attachments/assets/955b3452-136a-4bc7-b1b9-d81679c89825)
* With the option turned ON:
  ![image](https://github.com/user-attachments/assets/042ab986-fa06-4932-b17a-465123a7deb2)

If you have a good description for the option lmk and I'll add it!