### PR TITLE
Added support for multiple transferpak games

### DIFF
--- a/custom/mupen64plus-next_common.h
+++ b/custom/mupen64plus-next_common.h
@@ -76,8 +76,8 @@ extern char* retro_dd_path_img;
 extern char* retro_dd_path_rom;
 
 // Other Subsystems
-extern char* retro_transferpak_rom_path;
-extern char* retro_transferpak_ram_path;
+extern char* retro_transferpak_rom_path[4];
+extern char* retro_transferpak_ram_path[4];
 
 // Threaded GL Callback
 extern void gln64_thr_gl_invoke_command_loop();

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -159,8 +159,8 @@ char* retro_dd_path_img = NULL;
 char* retro_dd_path_rom = NULL;
 
 // Other Subsystems
-char* retro_transferpak_rom_path = NULL;
-char* retro_transferpak_ram_path = NULL;
+char* retro_transferpak_rom_path[4] = { NULL };
+char* retro_transferpak_ram_path[4] = { NULL };
 
 uint32_t CoreOptionCategoriesSupported = 0;
 uint32_t CoreOptionUpdateDisplayCbSupported = 0;
@@ -380,16 +380,19 @@ static void cleanup_global_paths()
         retro_dd_path_rom = NULL;
     }
 
-    if(retro_transferpak_rom_path)
+    for (size_t id = 0; id < 4; id++)
     {
-        free(retro_transferpak_rom_path);
-        retro_transferpak_rom_path = NULL;
-    }
-
-    if(retro_transferpak_ram_path)
-    {
-        free(retro_transferpak_ram_path);
-        retro_transferpak_ram_path = NULL;
+        if(retro_transferpak_rom_path[id])
+        {
+            free(retro_transferpak_rom_path[id]);
+            retro_transferpak_rom_path[id] = NULL;
+        }
+    
+        if(retro_transferpak_ram_path[id])
+        {
+            free(retro_transferpak_ram_path[id]);
+            retro_transferpak_ram_path[id] = NULL;
+        }
     }
 }
 
@@ -579,8 +582,11 @@ bool retro_load_game_special(unsigned game_type, const struct retro_game_info *i
         case RETRO_GAME_TYPE_TRANSFERPAK:
             if(num_info == 3)
             {
-                retro_transferpak_ram_path = strdup(info[0].path);
-                retro_transferpak_rom_path = strdup(info[1].path);
+                for (size_t i = 0; i < 4; i++)
+                {
+                    retro_transferpak_ram_path[i] = strdup(info[0].path);
+                    retro_transferpak_rom_path[i] = strdup(info[1].path);
+                }
             } else {
                 return false;
             }
@@ -1895,41 +1901,89 @@ bool retro_load_game(const struct retro_game_info *game)
     
     if (!retro_transferpak_rom_path && game->path)
     {
-       gamePath = (char *)game->path;
-       newPath = (char *)calloc(1, strlen(gamePath) + 4);
-       strcpy(newPath, gamePath);
-       strcat(newPath, ".gb");
-       FILE *fileTest = fopen(newPath, "r");
-       if (!fileTest)
-       {
-          free(newPath);
-       }
-       else
-       {
-          fclose(fileTest);
-          // Free'd later in Mupen Core
-          retro_transferpak_rom_path = newPath;
- 
-          // We have a gb rom!
-          if (!retro_transferpak_ram_path)
-          {
-             gamePath = (char *)game->path;
-             newPath = (char *)calloc(1, strlen(gamePath) + 5);
-             strcpy(newPath, gamePath);
-             strcat(newPath, ".sav");
-             FILE *fileTest = fopen(newPath, "r");
-             if (!fileTest)
-             {
+        gamePath = (char *)game->path;
+        char iToStr[2];
+        iToStr[0] = '1';
+        iToStr[1] = '\0';
+        for (size_t i = 0; i < 4; i++, iToStr[0]++)
+        {
+            newPath = (char *)calloc(1, strlen(gamePath) + 10);
+            strcpy(newPath, gamePath);
+            strcat(newPath, ".pak/");
+            strcat(newPath, iToStr);
+            strcat(newPath, ".gb");
+            FILE *fileTest = fopen(newPath, "r");
+            if (!fileTest)
+            {
                 free(newPath);
-             }
-             else
-             {
+            }
+            else
+            {
                 fclose(fileTest);
                 // Free'd later in Mupen Core
-                retro_transferpak_ram_path = newPath;
-             }
-          }
-       }
+                retro_transferpak_rom_path[i] = newPath;
+        
+                // We have a gb rom!
+                if (!retro_transferpak_ram_path[i])
+                {
+                    gamePath = (char *)game->path;
+                    newPath = (char *)calloc(1, strlen(gamePath) + 11);
+                    strcpy(newPath, gamePath);
+                    strcat(newPath, ".pak/");
+                    strcat(newPath, iToStr);
+                    strcat(newPath, ".sav");
+                    FILE *fileTest = fopen(newPath, "r");
+                    if (!fileTest)
+                    {
+                        free(newPath);
+                    }
+                    else
+                    {
+                        fclose(fileTest);
+                        // Free'd later in Mupen Core
+                        retro_transferpak_ram_path[i] = newPath;
+                    }
+                }
+                goto skip_generic_gb;
+            }
+
+            newPath = (char *)calloc(1, strlen(gamePath) + 4);
+            strcpy(newPath, gamePath);
+            strcat(newPath, ".gb");
+            fileTest = fopen(newPath, "r");
+            if (!fileTest)
+            {
+                free(newPath);
+            }
+            else
+            {
+                fclose(fileTest);
+                // Free'd later in Mupen Core
+                retro_transferpak_rom_path[i] = newPath;
+        
+                // We have a gb rom!
+                if (!retro_transferpak_ram_path[i])
+                {
+                    gamePath = (char *)game->path;
+                    newPath = (char *)calloc(1, strlen(gamePath) + 5);
+                    strcpy(newPath, gamePath);
+                    strcat(newPath, ".sav");
+                    FILE *fileTest = fopen(newPath, "r");
+                    if (!fileTest)
+                    {
+                        free(newPath);
+                    }
+                    else
+                    {
+                        fclose(fileTest);
+                        // Free'd later in Mupen Core
+                        retro_transferpak_ram_path[i] = newPath;
+                    }
+                }
+            }
+
+skip_generic_gb:
+        }
     }
  
     // Init default vals

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1899,7 +1899,7 @@ bool retro_load_game(const struct retro_game_info *game)
         }
     }
     
-    if (!retro_transferpak_rom_path && game->path)
+    if (game->path)
     {
         gamePath = (char *)game->path;
         char iToStr[2];
@@ -1907,6 +1907,9 @@ bool retro_load_game(const struct retro_game_info *game)
         iToStr[1] = '\0';
         for (size_t i = 0; i < 4; i++, iToStr[0]++)
         {
+            if (retro_transferpak_rom_path[i])
+                continue;
+
             newPath = (char *)calloc(1, strlen(gamePath) + 10);
             strcpy(newPath, gamePath);
             strcat(newPath, ".pak/");

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -380,7 +380,7 @@ static void cleanup_global_paths()
         retro_dd_path_rom = NULL;
     }
 
-    for (size_t id = 0; id < 4; id++)
+    for (int id = 0; id < 4; id++)
     {
         if(retro_transferpak_rom_path[id])
         {
@@ -582,7 +582,7 @@ bool retro_load_game_special(unsigned game_type, const struct retro_game_info *i
         case RETRO_GAME_TYPE_TRANSFERPAK:
             if(num_info == 3)
             {
-                for (size_t i = 0; i < 4; i++)
+                for (int i = 0; i < 4; i++)
                 {
                     retro_transferpak_ram_path[i] = strdup(info[0].path);
                     retro_transferpak_rom_path[i] = strdup(info[1].path);
@@ -1905,7 +1905,7 @@ bool retro_load_game(const struct retro_game_info *game)
         char iToStr[2];
         iToStr[0] = '1';
         iToStr[1] = '\0';
-        for (size_t i = 0; i < 4; i++, iToStr[0]++)
+        for (int i = 0; i < 4; i++, iToStr[0]++)
         {
             if (retro_transferpak_rom_path[i])
                 continue;

--- a/mupen64plus-core/src/backends/plugins_compat/input_plugin_compat.c
+++ b/mupen64plus-core/src/backends/plugins_compat/input_plugin_compat.c
@@ -115,7 +115,7 @@ static m64p_error input_plugin_get_input(void* opaque, uint32_t* input_)
         cin_compat->main_switch_pak(cin_compat->control_id);
         cin_compat->main_switch_pak = NULL;
         // If switching to Transfer Pak and if a rom path is set, Switch it
-        if(Controls[cin_compat->control_id].Plugin == PLUGIN_TRANSFER_PAK && retro_transferpak_rom_path)
+        if(Controls[cin_compat->control_id].Plugin == PLUGIN_TRANSFER_PAK && retro_transferpak_rom_path[cin_compat->control_id])
         {
             cin_compat->gb_cart_switch_enabled = 1;
         }

--- a/mupen64plus-core/src/main/main.c
+++ b/mupen64plus-core/src/main/main.c
@@ -1235,7 +1235,7 @@ static void init_gb_rom(void* opaque, void** storage, const struct storage_backe
 
     /* Ask the core loader for rom filename */
     char* rom_filename = (g_media_loader.get_gb_cart_rom == NULL)
-        ? (retro_transferpak_rom_path ? strdup(retro_transferpak_rom_path) : NULL)
+        ? (retro_transferpak_rom_path[data->control_id] ? strdup(retro_transferpak_rom_path[data->control_id]) : NULL)
         : g_media_loader.get_gb_cart_rom(g_media_loader.cb_data, data->control_id);
 
     /* Handle the no cart case */
@@ -1279,7 +1279,7 @@ static void init_gb_ram(void* opaque, size_t ram_size, void** storage, const str
 
     /* Ask the core loader for ram filename */
     char* ram_filename = (g_media_loader.get_gb_cart_ram == NULL)
-        ? (retro_transferpak_ram_path ? strdup(retro_transferpak_ram_path) : NULL)
+        ? (retro_transferpak_ram_path[data->control_id] ? strdup(retro_transferpak_ram_path[data->control_id]) : NULL)
         : g_media_loader.get_gb_cart_ram(g_media_loader.cb_data, data->control_id);
 
     /* Handle the no RAM case


### PR DESCRIPTION
## Description

This PR adds support for loading different GB games on transferpak for each controller. This allows, for example, to play Pokemon Red for P1, Blue for P2, and Yellow for P3 on Pokemon Stadium

## How it works (For the End-User)

Until now, you had to have both the .gb and .sav files alongside the N64 ROM (and with the same name), having this structure:

```
roms/
  n64/
    pokemon stadium.z64
    pokemon stadium.z64.gb
    pokemon stadium.z64.sav
```

But now you have to create a .pak folder and inside place the .gb and .sav files for every controller, naming them from 1.gb to 4.gb. For example:

```
roms/
  n64/
    pokemon stadium.z64
    pokemon stadium.z64.pak/
      1.gb
      1.sav
      2.gb
      2.sav
      3.gb
      3.sav
      4.gb
      4.sav
```

Also, you can combine both the old and the new methods (the newer one has higher priority). For example:

```
roms/
  n64/
    pokemon stadium.z64
    pokemon stadium.z64.gb
    pokemon stadium.z64.sav
    pokemon stadium.z64.pak/
      1.gb
      1.sav
```

With that, only the first player will have a different ROM while other players will use the same _pokemon stadium.z64.gb_ ROM.

## How it's implemented (for Libretro maintainers)

Now the global variables `retro_transferpak_rom_path` and `retro_transferpak_ram_path` are string arrays of fixed length of 4 (one for each controller). Then, on startup, the core will search for each .gb and .sav file (naming from 1 to 4) inside the `{GAME_FILE_NAME}.pak` folder. If there is no .gb or .sav file for that controller, then it'll rollback to the old method and, in case there are those files, it'll assign those files for that specific controller.

So, in pseudo code, it'd be something like this:

```c
rom_path[4], ram_path[4] as array of char*;
for (i = 0 to 4)
{
  if (file_exists("{GAME_FILENAME}.pak/{i}.gb")
  {
    rom_path[i] = "{GAME_FILENAME}.pak/{i}.gb";
    if (file_exists("{GAME_FILENAME}.pak/{i}.sav")
    {
      ram_path[i] = "{GAME_FILENAME}.pak/{i}.sav";
    }
  }
  if (empty(rom_path[i]) or empty(ram_path[i]))
  {
    if (file_exists("{GAME_FILENAME}.gb")
    {
      rom_path[i] = "{GAME_FILENAME}.gb";
      if (file_exists("{GAME_FILENAME}.sav")
      {
        ram_path[i] = "{GAME_FILENAME}.sav";
      }
    }
  }
}
```