### PR TITLE
Hide "EnableCopyColorFromRDRAM" for non-GLideN64 plugins

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -363,8 +363,8 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         CORE_NAME "-EnableCopyColorFromRDRAM",
         "Enable color buffer copy from RDRAM",
         NULL,
-        NULL,
-        NULL,
+        "(GLN64) Enable color buffer copy from RDRAM.",
+        "Enable color buffer copy from RDRAM.",
         "gliden64",
         {
             {"False", NULL},


### PR DESCRIPTION
Forgot to actually open the PR... :x I have it ready for 4 months now, sorry!

Without a description with `(GLN64)` in it the option isn't hidden when using other renderers.