### PR TITLE
Compile fix for libnx 4.9.0. Update mmap with the new virtmem API.

### DIFF
--- a/switch/mman.h
+++ b/switch/mman.h
@@ -29,7 +29,9 @@ static inline void *mmap(void *addr, size_t len, int prot, int flags, int fd, of
     (void)offset;
 
     size_t size = (len + 0xFFF) &~ 0xFFF;
-	ptr_rw = virtmemReserve(size);
+    virtmemLock();
+	ptr_rw = virtmemFindCodeMemory(size, 0);
+    virtmemUnlock();
     if (R_SUCCEEDED(svcMapProcessMemory(ptr_rw, envGetOwnProcessHandle(), (u64)addr, size)))
     {
         return ptr_rw;


### PR DESCRIPTION
I recently set up a development environment to build RetroArch for Switch. I could not compile this core so I looked into it and made a compile fix for the latest version if you consider updating to that. I don't know which libnx version is supposed to be used to compile the current develop.

This affects the the DynaRec compiler that I am not too familiar with but because it wants to allocate executable memory I picked an appropriate alloc routine for that. I have tested it with OoT and Banjo-Kazooie (previously uncompiled) and they ran without crashes but no longer sessions yet.