### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/custom/dependencies/libpng/pngrutil.c
+++ b/custom/dependencies/libpng/pngrutil.c
@@ -3149,10 +3149,13 @@ png_check_chunk_length(png_const_structrp png_ptr, const png_uint_32 length)
    {
       png_alloc_size_t idat_limit = PNG_UINT_31_MAX;
       size_t row_factor =
-         (png_ptr->width * png_ptr->channels * (png_ptr->bit_depth > 8? 2: 1)
-          + 1 + (png_ptr->interlaced? 6: 0));
+         (size_t)png_ptr->width
+         * (size_t)png_ptr->channels
+         * (png_ptr->bit_depth > 8? 2: 1)
+         + 1
+         + (png_ptr->interlaced? 6: 0);
       if (png_ptr->height > PNG_UINT_32_MAX/row_factor)
-         idat_limit=PNG_UINT_31_MAX;
+         idat_limit = PNG_UINT_31_MAX;
       else
          idat_limit = png_ptr->height * row_factor;
       row_factor = row_factor > 32566? 32566 : row_factor;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `png_check_chunk_length` that was cloned from `pnggroup/libpng` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `png_check_chunk_length` in `custom/dependencies/libpng/pngrutil.c`
* **Original Fix**: https://github.com/pnggroup/libpng/commit/8a05766cb74af05c04c53e6c9d60c13fc4d59bf2

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/pnggroup/libpng/commit/8a05766cb74af05c04c53e6c9d60c13fc4d59bf2
* [CVE-2018-13785](https://nvd.nist.gov/vuln/detail/CVE-2018-13785)

Please review and merge this PR to ensure your repository is protected against this vulnerability.