### PR TITLE
Add webOS to Makefile / CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,9 @@ include:
   # tvOS
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
 
 # Stages
 stages:
@@ -170,3 +173,15 @@ libretro-build-osx-arm64:
   extends:
     - .libretro-osx-arm64-make-default
     - .core-defs
+
+#################################### MISC ####################################
+# webOS 32-bit
+libretro-build-webos-armv7a-gles2:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs-gles2
+
+libretro-build-webos-armv7a-gles3:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs-gles3

--- a/Makefile
+++ b/Makefile
@@ -605,6 +605,19 @@ else
    CXXFLAGS += -fpermissive
 endif
 
+# webOS
+ifneq (,$(or $(findstring webos,$(CROSS_COMPILE)),$(findstring starfish,$(CROSS_COMPILE))))
+   # gitlab-ci uses GLES3 not FORCE_GLES3
+   ifeq ($(GLES3),1)
+      TARGET := $(TARGET_NAME)_gles3_libretro.so
+   else
+      # default to GLES v2
+      GLES = 1
+   endif
+   GL_LIB := -lGLESv2
+   HAVE_NEON = 1
+endif
+
 ifeq ($(STATIC_LINKING), 1)
    ifneq (,$(findstring win,$(platform)))
       TARGET := $(TARGET:.dll=.lib)


### PR DESCRIPTION
Fixes building on webOS which needs GLES (not GL).

It also changes the TARGET name to add gles 2 and gles 3 to the filename, because the gitlab buildbot was overwriting the previous compiled version, meaning gles 2 was never available to download.

A PR to update the info files has already been merged.

Now they can both be listed for download