### PR TITLE
GLideN64 graphical fixes

### DIFF
--- a/GLideN64/src/CommonPluginAPI.cpp
+++ b/GLideN64/src/CommonPluginAPI.cpp
@@ -5,6 +5,7 @@
 #endif // OS_WINDOWS
 
 #include "PluginAPI.h"
+#include "DisplayWindow.h"
 
 extern "C" {
 
@@ -79,4 +80,14 @@ EXPORT void CALL gln64FBWList(FrameBufferModifyEntry *plist, unsigned int size)
 	api().FBWList(plist, size);
 }
 #endif
+
+EXPORT void CALL gln64DestroyGfxContext(void)
+{
+	dwnd().destroyGfxContext();
+}
+
+EXPORT void CALL gln64ReinitGfxContext(void)
+{
+	dwnd().reinitGfxContext();
+}
 }

--- a/GLideN64/src/DisplayWindow.cpp
+++ b/GLideN64/src/DisplayWindow.cpp
@@ -44,6 +44,18 @@ void DisplayWindow::restart()
 	m_bResizeWindow = true;
 }
 
+void DisplayWindow::destroyGfxContext()
+{
+	m_drawer._destroyData();
+	gfxContext.destroy();
+}
+
+void DisplayWindow::reinitGfxContext()
+{
+	gfxContext.init();
+	m_drawer._initData();
+}
+
 void DisplayWindow::swapBuffers()
 {
 	m_drawer.drawOSD();

--- a/GLideN64/src/DisplayWindow.h
+++ b/GLideN64/src/DisplayWindow.h
@@ -10,6 +10,8 @@ public:
 	bool start();
 	void stop();
 	void restart();
+	void destroyGfxContext();
+	void reinitGfxContext();
 	void swapBuffers();
 	void saveScreenshot();
 	void saveBufferContent(FrameBuffer * _pBuffer);

--- a/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -53,13 +53,18 @@ void GLInfo::init() {
 	const char * strRenderer = reinterpret_cast<const char *>(glGetString(GL_RENDERER));
 
 	bool isAnyAdreno = strstr(strRenderer, "Adreno") != nullptr;
+	bool isFreedreno = strstr(strRenderer, "FD") != nullptr;  // freedreno uses "FDxxx" naming
+	bool isAdrenoFamily = isAnyAdreno || isFreedreno;
 
 	if (std::regex_match(std::string(strRenderer), std::regex("Adreno.*530")))
 		renderer = Renderer::Adreno530;
 	else if (std::regex_match(std::string(strRenderer), std::regex("Adreno.*540")) ||
-		std::regex_match(std::string(strRenderer), std::regex("Adreno.*6\\d\\d")))
+		std::regex_match(std::string(strRenderer), std::regex("Adreno.*6\\d\\d")) ||
+		std::regex_match(std::string(strRenderer), std::regex(".*FD6\\d\\d.*")))  // freedreno 6xx series
 		renderer = Renderer::Adreno_no_bugs;
-	else if (strstr(strRenderer, "Adreno") != nullptr)
+	else if (std::regex_match(std::string(strRenderer), std::regex(".*FD5\\d\\d.*")))  // freedreno 5xx series
+		renderer = Renderer::Adreno;
+	else if (isAdrenoFamily)
 		renderer = Renderer::Adreno;
 	else if (strstr(strRenderer, "VideoCore IV") != nullptr)
 		renderer = Renderer::VideoCore;

--- a/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -207,6 +207,13 @@ void GLInfo::init() {
 	eglImage = (Utils::isEGLExtensionSupported("EGL_KHR_image_base") || Utils::isEGLExtensionSupported("EGL_KHR_image"));
 	ext_fetch_arm =  Utils::isExtensionSupported(*this, "GL_ARM_shader_framebuffer_fetch") && !ext_fetch;
 
+	// Disable framebuffer fetch on freedreno desktop - causes rendering issues
+	if (isFreedreno && !isGLESX) {
+		ext_fetch = false;
+		ext_fetch_arm = false;
+		n64DepthWithFbFetch = false;
+	}
+
 	dual_source_blending = false; //!isGLESX || ((!isGLES2) && (Utils::isExtensionSupported(*this, "GL_EXT_blend_func_extended") && !isAnyAdreno));
 	anisotropic_filtering = Utils::isExtensionSupported(*this, "GL_EXT_texture_filter_anisotropic");
 

--- a/custom/mupen64plus-next_common.h
+++ b/custom/mupen64plus-next_common.h
@@ -83,6 +83,10 @@ extern char* retro_transferpak_ram_path;
 extern void gln64_thr_gl_invoke_command_loop();
 extern bool threaded_gl_safe_shutdown;
 
+// GLN64 context management (for libretro context_destroy/context_reset)
+extern void gln64DestroyGfxContext(void);
+extern void gln64ReinitGfxContext(void);
+
 // Core options
 extern uint32_t CoreOptionCategoriesSupported;
 extern uint32_t CoreOptionUpdateDisplayCbSupported;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1811,6 +1811,15 @@ void context_reset(void)
           glsm_ctl(GLSM_CTL_STATE_SETUP, NULL);
           context_setup_first_init = true;
        }
+       // Reinitialize GLideN64's graphics context when the GL context is recreated
+       // (e.g., during fullscreen toggle). This is needed because BufferedDrawer uses
+       // persistent buffer mappings (GL_MAP_PERSISTENT_BIT) which become invalid when
+       // the GL context is destroyed and recreated.
+       if (emu_initialized)
+       {
+          gln64DestroyGfxContext();
+          gln64ReinitGfxContext();
+       }
     }
 
     reinit_gfx_plugin();


### PR DESCRIPTION
Reinitialize GLideN64's graphics context when the GL context is recreated.
Detect Freedreno chips and disable ext_fetch there.

I needed this to get recognizable graphics on my Qualcomm based device.