### PR TITLE
Makefile: auto-enable MESA for rpi5 platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ else ifneq (,$(findstring rpi,$(platform)))
       GLES3 = 1
       MESA = 1
    endif
+   ifneq (,$(findstring rpi5,$(platform)))
+      GLES3 = 1
+      MESA = 1
+   endif
    ifeq ($(MESA), 1)
       GL_LIB := -lGLESv2
    else


### PR DESCRIPTION
Pi 5 ships only with the Mesa V3D driver; the legacy Broadcom VideoCore (-lbrcmGLESv2, /opt/vc) path does not exist. Without MESA=1 the rpi5 target fell through to the VideoCore branch and failed to link (or linked against the wrong GLES stack). Mirror the rpi4 behavior so platform=rpi5/rpi5_64 builds out of the box.

`make clean && make platform=rpi5_64 -j4`

Built and verified it fixes the built core on my rpi5 running ubuntu. Thanks!