### PR TITLE
Fixes crash on retro_reset with GL/Vulkan when using parallel RSP and portable rand() calls sidestepping the need for MINGW ifdefs

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -464,13 +464,7 @@ static void* EmuThreadFunction(void* param)
 
             uint32_t reg_id = 0;
             while (reg_id == 0)
-            {
-#ifdef __MINGW32__
-                rand_s(&reg_id);
-#else
-                reg_id = rand();
-#endif
-            }
+		reg_id = ((unsigned)rand() << 16) ^ (unsigned)rand() ^ (unsigned)time(NULL);
             reg_id += netplay_player;
 
             if (CoreDoCommand(M64CMD_NETPLAY_CONTROL_PLAYER, netplay_player, &reg_id) == M64ERR_SUCCESS)
@@ -2100,7 +2094,7 @@ void retro_run (void)
 
 void retro_reset (void)
 {
-    CoreDoCommand(M64CMD_RESET, 0, (void*)0);
+    CoreDoCommand(M64CMD_RESET, 1, (void*)0);
 }
 
 void *retro_get_memory_data(unsigned type)


### PR DESCRIPTION
* Portable rand() calls sidestepping the need for Mingw ifdefs. The current code as-is refused to compile on mingw/msys2 GCC 15.2.0 anyway
* Fixes nasty deadlock when resetting with ('h') between Mupen64plus' soft-reset path and the parallel rsp plugin, uses hard reset instead. Both GL and Vulkan video drivers both were locking up when invoking a reset