### PR TITLE
Add support for 16KB pages on Android.

### DIFF
--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -85,7 +85,7 @@ LOCAL_SRC_FILES        := $(SOURCES_CXX) $(SOURCES_C) $(SOURCES_ASM) $(SOURCES_N
 LOCAL_ASMFLAGS         := $(COREASMFLAGS)
 LOCAL_CPPFLAGS         := -std=gnu++11 $(CXXFLAGS) $(COREFLAGS)
 LOCAL_CFLAGS           := $(CFLAGS) $(COREFLAGS)
-LOCAL_LDFLAGS          := -Wl,-version-script=$(LIBRETRO_DIR)/link.T
+LOCAL_LDFLAGS          := -Wl,-version-script=$(LIBRETRO_DIR)/link.T,-z,max-page-size=16384
 LOCAL_LDLIBS           := -llog -lEGL $(GLLIB) $(CORELDLIBS)
 LOCAL_STATIC_LIBRARIES := 
 LOCAL_CPP_FEATURES     := exceptions


### PR DESCRIPTION
Since last year Google is requiring every application on Google Play to support 16KB pages: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

It's a tiny build script change, I've tested it locally and it's working fine.

We did a test pilot with fceumm (https://github.com/libretro/libretro-fceumm/pull/644) and now I'm creating all the PRs for the other cores.