### PR TITLE
webOS: fix build on 64-bit and use of TEXTURE_EXTERNAL

### DIFF
--- a/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/GLideN64/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -229,6 +229,11 @@ void GLInfo::init() {
 
 	eglImageFramebuffer = eglImage && !isGLES2;
 
+#ifdef WEBOS
+	eglImage = false;
+	eglImageFramebuffer = false;
+#endif
+
 	if (config.frameBufferEmulation.N64DepthCompare != Config::dcDisable) {
 		if (config.frameBufferEmulation.N64DepthCompare == Config::dcFast) {
 			if (!imageTexturesInterlock && !n64DepthWithFbFetch) {

--- a/Makefile
+++ b/Makefile
@@ -614,8 +614,15 @@ ifneq (,$(or $(findstring webos,$(CROSS_COMPILE)),$(findstring starfish,$(CROSS_
       # default to GLES v2
       GLES = 1
    endif
+   CPUFLAGS += -DWEBOS
    GL_LIB := -lGLESv2
-   HAVE_NEON = 1
+   ifneq (,$(findstring aarch64,$(CROSS_COMPILE)))
+      WITH_DYNAREC=aarch64
+      HAVE_NEON = 0
+   else
+      WITH_DYNAREC=arm
+      HAVE_NEON = 1
+   endif
 endif
 
 ifeq ($(STATIC_LINKING), 1)


### PR DESCRIPTION
Currently adding aarch64 support and needs a little fix.

I also noticed it will set eglImage and eglImageFramebuffer to true, this causes a segfault later in the mali driver as it cannot bind a external texture without backing.