### PR TITLE
Fix ParaLLEl-RDP interlaced Bob output and add Bob - Sharp / Blend modes

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1655,9 +1655,29 @@ static void update_variables(bool startup)
         var.key = CORE_NAME "-parallel-rdp-deinterlace-method";
         var.value = NULL;
         if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-            parallel_set_interlacing(!strcmp(var.value, "Weave"));
+        {
+            if (!strcmp(var.value, "Weave"))
+            {
+                parallel_set_interlacing(true);
+                parallel_set_deinterlace_mode(PARALLEL_DEINTERLACE_WEAVE);
+            }
+            else
+            {
+                parallel_set_interlacing(false);
+
+                if (!strcmp(var.value, "Bob_Sharp"))
+                    parallel_set_deinterlace_mode(PARALLEL_DEINTERLACE_BOB_SHARP);
+                else if (!strcmp(var.value, "Blend"))
+                    parallel_set_deinterlace_mode(PARALLEL_DEINTERLACE_BLEND);
+                else
+                    parallel_set_deinterlace_mode(PARALLEL_DEINTERLACE_BOB);
+            }
+        }
         else
+        {
             parallel_set_interlacing(false);
+            parallel_set_deinterlace_mode(PARALLEL_DEINTERLACE_BOB);
+        }
     }
 #endif
 

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1235,11 +1235,13 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         CORE_NAME "-parallel-rdp-deinterlace-method",
         "(ParaLLEl-RDP) Deinterlacing method",
         "Deinterlacing method",
-        "Weave should only be used with 1x scaling factor and special CRT shaders.",
+        "Select how ParaLLEl-RDP handles interlaced VI output. Bob - Sharp uses nearest sampling for cleaner x2/x4 output.",
         NULL,
         "parallel_rdp",
         {
             { "Bob", NULL },
+            { "Bob_Sharp", "Bob - Sharp" },
+            { "Blend", NULL },
             { "Weave", NULL },
             { NULL, NULL },
         }

--- a/mupen64plus-video-paraLLEl/parallel-rdp/parallel-rdp/video_interface.cpp
+++ b/mupen64plus-video-paraLLEl/parallel-rdp/parallel-rdp/video_interface.cpp
@@ -1111,6 +1111,10 @@ Vulkan::ImageHandle VideoInterface::upscale_deinterlace(Vulkan::CommandBuffer &c
 	{
 		float y_offset;
 	} push = {};
+
+	// Bob keeps ParaLLEl-RDP's historical quarter-line field compensation.
+	// Bob - Sharp uses the same field placement, but nearest sampling avoids
+	// mixing neighbouring lines when the internal scale is already x2/x4.
 	push.y_offset = (float(scaling_factor) * (field_select ? -0.25f : +0.25f)) / float(scale_image.get_height());
 	cmd.push_constants(&push, 0, sizeof(push));
 
@@ -1121,7 +1125,9 @@ Vulkan::ImageHandle VideoInterface::upscale_deinterlace(Vulkan::CommandBuffer &c
 #else
 	cmd.set_program(device->request_program(shader_bank->vi_deinterlace_vert, shader_bank->vi_deinterlace_frag));
 #endif
-	cmd.set_texture(0, 0, scale_image.get_view(), Vulkan::StockSampler::LinearClamp);
+	cmd.set_texture(0, 0, scale_image.get_view(),
+	                options.deinterlace_mode == ScanoutOptions::DeinterlaceMode::BobSharp ?
+	                Vulkan::StockSampler::NearestClamp : Vulkan::StockSampler::LinearClamp);
 	cmd.draw(3);
 	cmd.end_render_pass();
 	return deinterlaced_image;
@@ -1354,9 +1360,14 @@ Vulkan::ImageHandle VideoInterface::scanout(VkImageLayout target_layout, const S
 	else
 		divot_image = std::move(aa_image);
 
-	// Scale pass
-	bool is_final_pass = !downscale_steps || scaling_factor <= 1;
+	// Scale pass.
 	bool serrate = (regs.status & VI_CONTROL_SERRATE_BIT) != 0;
+	bool needs_downscale = downscale_steps && scaling_factor > 1;
+	bool needs_upscale_deinterlace = serrate && options.upscale_deinterlacing;
+	bool needs_blend_deinterlace = serrate &&
+	                                options.deinterlace_mode == ScanoutOptions::DeinterlaceMode::Blend &&
+	                                prev_scanout_image;
+	bool is_final_pass = !needs_downscale && !needs_upscale_deinterlace && !needs_blend_deinterlace;
 
 	auto scale_image = scale_stage(*cmd, divot_image.get(),
 	                               regs, lines,
@@ -1364,22 +1375,24 @@ Vulkan::ImageHandle VideoInterface::scanout(VkImageLayout target_layout, const S
 	                               is_final_pass);
 
 	auto src_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	unsigned output_scaling_factor = scaling_factor;
 
-	if (!is_final_pass && scale_image)
+	if (needs_downscale && scale_image)
 	{
 		cmd->image_barrier(*scale_image, src_layout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
 		                   layout_to_stage(src_layout), layout_to_access(src_layout),
 		                   VK_PIPELINE_STAGE_TRANSFER_BIT, VK_ACCESS_TRANSFER_READ_BIT);
 
-		is_final_pass = !serrate || !options.upscale_deinterlacing;
+		is_final_pass = !needs_upscale_deinterlace && !needs_blend_deinterlace;
 
 		scale_image = downscale_stage(*cmd, *scale_image, scaling_factor, downscale_steps,
-									  options, is_final_pass);
+		                              options, is_final_pass);
+		output_scaling_factor = std::max(1, scaling_factor >> downscale_steps);
 
 		src_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 	}
 
-	if (!is_final_pass && scale_image)
+	if (needs_upscale_deinterlace && scale_image)
 	{
 		cmd->image_barrier(*scale_image, src_layout, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
 		                   layout_to_stage(src_layout), layout_to_access(src_layout),
@@ -1387,9 +1400,52 @@ Vulkan::ImageHandle VideoInterface::scanout(VkImageLayout target_layout, const S
 
 		bool field_state = regs.v_current_line == 0;
 		scale_image = upscale_deinterlace(*cmd, *scale_image,
-		                                  std::max(1, scaling_factor >> downscale_steps),
+		                                  output_scaling_factor,
 		                                  field_state, options);
 		src_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	}
+
+	if (needs_blend_deinterlace && scale_image)
+	{
+		if (src_layout != VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+		{
+			cmd->image_barrier(*scale_image, src_layout, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+			                   layout_to_stage(src_layout), layout_to_access(src_layout),
+			                   VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+			                   VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+			src_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		}
+
+		Vulkan::RenderPassInfo rp;
+		rp.color_attachments[0] = &scale_image->get_view();
+		rp.num_color_attachments = 1;
+		rp.load_attachments = 1;
+		rp.store_attachments = 1;
+
+		cmd->begin_render_pass(rp);
+		cmd->set_opaque_state();
+		cmd->set_blend_enable(true);
+		cmd->set_blend_factors(VK_BLEND_FACTOR_CONSTANT_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA);
+		cmd->set_color_write_mask(0x7);
+		const float blend_constants[4] = { 0.5f, 0.5f, 0.5f, 0.5f };
+		cmd->set_blend_constants(blend_constants);
+
+		struct Push
+		{
+			float y_offset;
+		} push = {};
+		cmd->push_constants(&push, 0, sizeof(push));
+
+#ifdef PARALLEL_RDP_SHADER_DIR
+		cmd->set_program("rdp://vi_deinterlace.vert", "rdp://vi_deinterlace.frag", {
+			{ "DEBUG_ENABLE", debug_channel ? 1 : 0 },
+		});
+#else
+		cmd->set_program(device->request_program(shader_bank->vi_deinterlace_vert, shader_bank->vi_deinterlace_frag));
+#endif
+		cmd->set_texture(0, 0, prev_scanout_image->get_view(), Vulkan::StockSampler::LinearClamp);
+		cmd->draw(3);
+		cmd->end_render_pass();
 	}
 
 	if (scale_image)

--- a/mupen64plus-video-paraLLEl/parallel-rdp/parallel-rdp/video_interface.hpp
+++ b/mupen64plus-video-paraLLEl/parallel-rdp/parallel-rdp/video_interface.hpp
@@ -58,10 +58,19 @@ struct ScanoutOptions
 	// Not hardware accurate, but needed for weave interlace mode.
 	bool blend_previous_frame = false;
 
+	enum class DeinterlaceMode
+	{
+		Bob = 0,
+		BobSharp = 1,
+		Blend = 2,
+		Weave = 3
+	};
+
 	// Upscale deinterlacing deinterlaces by upscaling in Y, with an Y coordinate offset matching the field.
 	// If disabled, weave interlacing is used.
 	// Weave deinterlacing should *not* be used, except to run test suite!
 	bool upscale_deinterlacing = true;
+	DeinterlaceMode deinterlace_mode = DeinterlaceMode::Bob;
 
 	struct
 	{

--- a/mupen64plus-video-paraLLEl/parallel.cpp
+++ b/mupen64plus-video-paraLLEl/parallel.cpp
@@ -186,6 +186,11 @@ void parallel_set_interlacing(bool enable)
 	RDP::interlacing = enable;
 }
 
+void parallel_set_deinterlace_mode(enum parallel_deinterlace_mode mode)
+{
+	RDP::deinterlace_mode = mode;
+}
+
 void parallel_profile_video_refresh_begin(void)
 {
 	RDP::profile_refresh_begin();

--- a/mupen64plus-video-paraLLEl/parallel.h
+++ b/mupen64plus-video-paraLLEl/parallel.h
@@ -25,6 +25,16 @@ void parallel_set_vi_scale(bool enable);
 void parallel_set_dither_filter(bool enable);
 void parallel_set_interlacing(bool enable);
 
+enum parallel_deinterlace_mode
+{
+   PARALLEL_DEINTERLACE_BOB = 0,
+   PARALLEL_DEINTERLACE_BOB_SHARP = 1,
+   PARALLEL_DEINTERLACE_BLEND = 2,
+   PARALLEL_DEINTERLACE_WEAVE = 3
+};
+
+void parallel_set_deinterlace_mode(enum parallel_deinterlace_mode mode);
+
 void parallel_set_upscaling(unsigned factor, bool super_sampled_read_back);
 void parallel_set_super_sampled_read_back_dither(bool enable);
 void parallel_set_downscaling_steps(unsigned steps);

--- a/mupen64plus-video-paraLLEl/rdp.cpp
+++ b/mupen64plus-video-paraLLEl/rdp.cpp
@@ -37,6 +37,7 @@ bool native_tex_rect = true;
 bool synchronous = true, divot_filter = true, gamma_dither = true;
 bool vi_aa = true, vi_scale = true, dither_filter = true;
 bool interlacing = true, super_sampled_read_back = false, super_sampled_dither = true;
+unsigned deinterlace_mode = PARALLEL_DEINTERLACE_BOB;
 
 static const unsigned cmd_len_lut[64] = {
 	1, 1, 1, 1, 1, 1, 1, 1, 4, 6, 12, 14, 12, 14, 20, 22,
@@ -368,8 +369,13 @@ void complete_frame()
 	opts.vi.dither_filter = dither_filter;
 	opts.vi.divot_filter = divot_filter;
 	opts.vi.gamma_dither = gamma_dither;
-	opts.blend_previous_frame = interlacing;
-	opts.upscale_deinterlacing = !interlacing;
+	opts.deinterlace_mode = static_cast<ScanoutOptions::DeinterlaceMode>(deinterlace_mode);
+
+	// Weave keeps ParaLLEl-RDP's historical previous-field path.
+	// Bob and Blend are progressive-output paths; Blend averages the Bob output
+	// with the previous scanout to reduce flicker.
+	opts.blend_previous_frame = deinterlace_mode == PARALLEL_DEINTERLACE_WEAVE;
+	opts.upscale_deinterlacing = !opts.blend_previous_frame;
 	opts.downscale_steps = downscaling_steps;
 	opts.crop_overscan_pixels = overscan;
 	auto image = frontend->scanout(opts);

--- a/mupen64plus-video-paraLLEl/rdp.hpp
+++ b/mupen64plus-video-paraLLEl/rdp.hpp
@@ -26,6 +26,7 @@ extern unsigned height;
 extern unsigned upscaling;
 extern unsigned overscan;
 extern unsigned downscaling_steps;
+extern unsigned deinterlace_mode;
 extern bool synchronous, divot_filter, gamma_dither, vi_aa, vi_scale, dither_filter, interlacing;
 extern bool native_texture_lod, native_tex_rect, super_sampled_read_back, super_sampled_dither;
 


### PR DESCRIPTION
## Summary

This PR fixes the ParaLLEl-RDP Bob deinterlacing path by making Bob explicitly run as a final deinterlacing pass when the VI is in serrate/interlaced mode, instead of relying on the previous final-pass/downscale path where the pass could be skipped or applied inconsistently.

The corrected `Bob` mode now applies the field offset consistently to produce a stable progressive output from interlaced fields. This PR also adds `Bob - Sharp`, which uses the same corrected Bob path but switches to nearest filtering to avoid vertical line blending at higher internal resolutions.

A `Blend` mode is also added as a softer deinterlacing option alongside `Weave`.

## Modes

* `Bob`: corrected field-offset Bob deinterlacing.
* `Bob - Sharp`: corrected Bob path with nearest filtering for a sharper result at higher internal resolutions.
* `Blend`: softer field-blending deinterlacing option.
* `Weave`: existing weave-style behavior.

This patch was prepared with AI assistance, so if maintainers prefer a different implementation, naming, or structure, I am completely fine with it being adjusted or rewritten.

Still, the result is much more stable than the default Bob deinterlacing, especially at higher resolution.

You can find builds here : https://github.com/Immersion95/mupen64plus-libretro-nx/actions/runs/27217496700