### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,10 @@ include:
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
   # MacOS
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -98,6 +102,17 @@ libretro-build-linux-x64:
     LLE: 1
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  variables:
+    HAVE_PARALLEL_RDP: 1
+    HAVE_PARALLEL_RSP: 1
+    HAVE_THR_AL: 1
+    LLE: 1
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Android ARMv7a


### PR DESCRIPTION
The buildbot publishes `mupen64plus_next_libretro.so` for linux/x86_64 and linux/x86, but there is no desktop Linux ARM64 build — `.gitlab-ci.yml` has no aarch64 job, so nothing is produced for that platform, even though the core already carries an aarch64 dynarec (`NEW_DYNAREC=4`, `new_dynarec/arm64/linkage_arm64.S`).

This adds the `/linux-aarch64.yml` template include and a `libretro-build-linux-aarch64` job carrying the same variables as the existing x64 one (`HAVE_PARALLEL_RDP`, `HAVE_PARALLEL_RSP`, `HAVE_THR_AL`, `LLE`). No image or compiler override is needed: the `libretro-build-aarch64-ubuntu` image installs gcc-12/g++-12 and points `gcc`/`g++` at them through `update-alternatives`.

**Verified on real aarch64 hardware, and not only as a build:**

- Builds clean from this branch with those variables set.
- The dynarec is the one that gets used: the core logs `Starting R4300 emulator: Dynamic Recompiler` / `Init new dynarec`, not the interpreter.
- Mario Kart 64 runs in RetroArch on aarch64 — through the boot sequence and intro into the MAP SELECT menu, with the cups, the track preview and the track list all rendering correctly through GLideN64 (RetroArch negotiated a `glcore` 3.3 context). No errors in the RetroArch log.

Two notes for whoever reviews this, since neither is caused by the change but both could bite someone reproducing it:

- **ParaLLEl-RDP could not be exercised on this particular device.** The GPU here is an Adreno 618 on Mesa/Turnip, which does not expose `VK_KHR_16bit_storage` for SSBOs, and paraLLEl-RDP refuses to start without it. That is a driver limitation on my hardware, not an ARM64 problem — the job still builds paraLLEl-RDP, and the GLideN64 path is verified above.
- **`parallel-rdp/util/aligned_alloc.cpp` needs `#include <cstdint>` on GCC 13+**, which no longer pulls it in transitively; it fails there with `'uintptr_t' was not declared in this scope`. It is unrelated to architecture and does not affect the CI image (gcc-12), so it is deliberately not part of this PR — but it will surface for anyone building with a newer toolchain, and belongs upstream in parallel-rdp.

Only the Linux ARM64 job is added; nothing else in the file changes.