### PR TITLE
libretro: support booting a bare 64DD disk image

### DIFF
--- a/.github/workflows/retroxr-release.yml
+++ b/.github/workflows/retroxr-release.yml
@@ -69,9 +69,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y g++-mingw-w64-x86-64 nasm binutils make zip
 
+      # No `submodules: recursive`, unlike the other retroXR core forks. This
+      # repository has no .gitmodules at all -- everything it vendors came in
+      # through git subrepo, which commits the trees -- and it carries one
+      # leftover gitlink, mupen64plus-rsp-paraLLEl/lightning/gnulib, with no
+      # entry to match. Asking for submodules therefore cannot succeed on any
+      # ref: `fatal: No url found for submodule path ... in .gitmodules`,
+      # exit 128, before a line is compiled. Nothing is missing without it.
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       # CC/CXX are passed on the command line rather than left to the makefile's
@@ -120,9 +126,15 @@ jobs:
           unzip -q "$RUNNER_TEMP/ndk.zip" -d "$RUNNER_TEMP"
           echo "$RUNNER_TEMP/android-ndk-r27d" >> $GITHUB_PATH
 
+      # No `submodules: recursive`, unlike the other retroXR core forks. This
+      # repository has no .gitmodules at all -- everything it vendors came in
+      # through git subrepo, which commits the trees -- and it carries one
+      # leftover gitlink, mupen64plus-rsp-paraLLEl/lightning/gnulib, with no
+      # entry to match. Asking for submodules therefore cannot succeed on any
+      # ref: `fatal: No url found for submodule path ... in .gitmodules`,
+      # exit 128, before a line is compiled. Nothing is missing without it.
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       # GLES3=1 is the whole difference between the two Android cores the

--- a/.github/workflows/retroxr-release.yml
+++ b/.github/workflows/retroxr-release.yml
@@ -1,0 +1,217 @@
+# Build the retroXR mupen64plus-next core for Windows and Android and publish it
+# as a release, so retroXR's CoreDownloadManager can fetch it.
+#
+# This fork makes the core boot a BARE 64DD disk image -- Mario Artist, Kyojin
+# no Doshin, everything that shipped on a disk and no cartridge. The core could
+# always do it; none of it was reachable, because emu_step_load_data() always
+# issued M64CMD_ROM_OPEN, so is_valid_rom() rejected a disk and M64CMD_DISK_OPEN
+# was never sent. A disk is now detected in retro_load_game (by .ndd, by the two
+# canonical dump sizes, or by the region word in either endianness, with carts
+# ruled out first), g_media_loader.get_dd_disk is supplied, and a close on the
+# disk path sends DISK_CLOSE rather than a ROM_CLOSE the core refuses.
+#
+# It also fixes an out-of-bounds read on the num_info == 1 branch of
+# RETRO_GAME_TYPE_DD, a NULL/SIZE_MAX memory descriptor exported when there is no
+# cartridge, and a block-number/loop-index mix-up in the disk format scan.
+#
+#   Windows  mupen64plus_next_libretro.dll.zip
+#              containing mupen64plus_next_libretro.dll
+#   Android  mupen64plus_next_gles3_libretro_android.so.zip
+#              containing mupen64plus_next_gles3_libretro_android.so
+#
+# The two platforms carry DIFFERENT core names, and that is the buildbot's doing
+# rather than ours: it publishes only plain mupen64plus_next for Windows and only
+# the _gles2 and _gles3 variants for Android. retroXR replaces the stock build in
+# place and so has to match those names exactly -- which is why the Android job
+# passes GLES3=1 and names its asset for the gles3 core. Measured on a Quest, the
+# gles2 build runs at full speed and never draws a pixel.
+#
+# Windows is cross-compiled from Ubuntu with mingw-w64. Two variables have to be
+# passed explicitly and neither can be inferred from the host:
+#
+#   platform=win     the makefile picks its platform from uname, so a Linux host
+#                    silently produces a unix target.
+#   MSYSTEM=MINGW64  the Windows branch keys WITH_DYNAREC, ASFLAGS and -DWIN64
+#                    off MSYSTEM, an MSYS2 environment variable that does not
+#                    exist on a plain Ubuntu runner. Unset, NEITHER sub-branch is
+#                    taken: no dynarec, no -f win64 for nasm, no WIN64 define.
+#
+# The release must NOT be a prerelease: the download URL is the /releases/latest/
+# form so shipping a build needs no app update, and GitHub's `latest` skips
+# prereleases. Anything else cut on this fork should be marked prerelease.
+name: retroXR core release
+
+on:
+  push:
+    tags:
+      - 'retroxr-mupen64plus-next-libretro-v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag or SHA to build'
+        required: true
+        default: 'retroxr'
+      tag:
+        description: 'Release tag to publish as (leave blank to build without publishing)'
+        required: false
+        default: ''
+
+jobs:
+  windows:
+    name: Windows x86_64 (mingw-w64)
+    runs-on: ubuntu-latest
+    steps:
+      # nasm builds the x86_64 dynarec's .asm sources, and binutils `strings`
+      # feeds tools/gen_asm_defines.awk the defines it scrapes out of a compiled
+      # object. Neither is pulled in by g++-mingw-w64.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-mingw-w64-x86-64 nasm binutils make zip
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      # CC/CXX are passed on the command line rather than left to the makefile's
+      # `CC ?= x86_64-w64-mingw32-gcc`, which never fires: make defines CC as a
+      # built-in, so `?=` sees it already set and the build runs the host gcc.
+      - name: Build
+        run: |
+          make platform=win MSYSTEM=MINGW64 \
+            CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ \
+            -j$(nproc)
+
+      - name: Package
+        run: |
+          mapfile -t hits < <(find . -maxdepth 2 -name 'mupen64plus_next_libretro.dll' -type f)
+          if [ "${#hits[@]}" -ne 1 ]; then
+            echo "expected exactly one mupen64plus_next_libretro.dll, found ${#hits[@]}:"
+            printf '  %s\n' "${hits[@]}"
+            exit 1
+          fi
+          mkdir -p stage
+          cp "${hits[0]}" stage/mupen64plus_next_libretro.dll
+          (cd stage && zip -q -X ../mupen64plus_next_libretro.dll.zip mupen64plus_next_libretro.dll)
+          file stage/mupen64plus_next_libretro.dll
+          ls -lh mupen64plus_next_libretro.dll.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows
+          path: mupen64plus_next_libretro.dll.zip
+          if-no-files-found: error
+
+  android:
+    name: Android arm64-v8a (GLES3)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget unzip zip
+          # Into RUNNER_TEMP, NOT the workspace. This step runs before
+          # actions/checkout, and checkout clears the workspace it checks into --
+          # so an NDK unpacked at $PWD here exists at the end of this step and is
+          # gone by the time the build runs. The failure is a bare
+          # "ndk-build: command not found", which says nothing about why.
+          wget -q -O "$RUNNER_TEMP/ndk.zip" https://dl.google.com/android/repository/android-ndk-r27d-linux.zip
+          unzip -q "$RUNNER_TEMP/ndk.zip" -d "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/android-ndk-r27d" >> $GITHUB_PATH
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      # GLES3=1 is the whole difference between the two Android cores the
+      # buildbot publishes: it links GLESv3 instead of GLESv2 and leaves the
+      # makefile's GLES fallback unset. Application.mk says APP_ABI := all, so
+      # arm64-v8a is named to build the one ABI retroXR ships. That ABI also
+      # turns on the ParaLLEl RSP and RDP, which is the renderer a cartridge-less
+      # 64DD boot needs -- GLideN64 reaches the IPL logo and then draws nothing.
+      - name: Build
+        run: |
+          cd libretro/jni
+          ndk-build GLES3=1 APP_ABI=arm64-v8a -j$(nproc)
+
+      # LOCAL_MODULE is `retro`, so ndk-build emits libretro.so -- a name that
+      # says nothing about which core it is. It is renamed on the way into the
+      # zip to the name the asset advertises and the installer expects.
+      - name: Package
+        run: |
+          # libs/, not obj/. ndk-build leaves an unstripped copy in
+          # obj/local/<abi>/ and INSTALLS the deliverable to libs/<abi>/, so a
+          # search for the bare name finds two and the bigger one is the wrong
+          # one. The exactly-one check below is what turned that into a failed
+          # run rather than a core shipped with its debug info attached.
+          mapfile -t hits < <(find libretro -path '*/libs/arm64-v8a/*' -name 'libretro.so' -type f)
+          if [ "${#hits[@]}" -ne 1 ]; then
+            echo "expected exactly one arm64-v8a libretro.so, found ${#hits[@]}:"
+            printf '  %s\n' "${hits[@]}"
+            exit 1
+          fi
+          mkdir -p stage
+          cp "${hits[0]}" stage/mupen64plus_next_gles3_libretro_android.so
+          (cd stage && zip -q -X ../mupen64plus_next_gles3_libretro_android.so.zip mupen64plus_next_gles3_libretro_android.so)
+          file stage/mupen64plus_next_gles3_libretro_android.so
+          ls -lh mupen64plus_next_gles3_libretro_android.so.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android
+          path: mupen64plus_next_gles3_libretro_android.so.zip
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs: [windows, android]
+    if: github.event_name == 'push' || github.event.inputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          ls -lh dist
+          cat > notes.md <<EOF
+          mupen64plus-next libretro core built for retroXR, from \`$GITHUB_SHA\`.
+
+          Windows x86_64 and Android arm64-v8a. The source for these binaries is
+          this tag.
+
+          Over the stock buildbot build this boots a bare 64DD disk image -- a
+          disk with no cartridge, which the core could always run and no
+          frontend could ever ask it to, because the load path issued
+          M64CMD_ROM_OPEN unconditionally and is_valid_rom() rejected a disk.
+          A disk is now detected at load, g_media_loader.get_dd_disk is
+          supplied, and the disk path closes with DISK_CLOSE.
+
+          It also fixes an out-of-bounds read on the one-ROM branch of
+          RETRO_GAME_TYPE_DD, a NULL/SIZE_MAX memory descriptor exported when no
+          cartridge is present, and a block-number/loop-index mix-up in the disk
+          format scan.
+
+          The Android asset is the gles3 core, matching the buildbot's naming:
+          it publishes no plain mupen64plus_next for Android, and the gles2
+          build runs at full speed on a Quest without drawing a pixel.
+          EOF
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "mupen64plus-next (retroXR build) $TAG" \
+              --notes-file notes.md
+          fi
+          gh release upload "$TAG" \
+            dist/mupen64plus_next_libretro.dll.zip \
+            dist/mupen64plus_next_gles3_libretro_android.so.zip \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/Makefile
+++ b/Makefile
@@ -679,6 +679,7 @@ else
 endif
 
 OBJECTS     += $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o) $(SOURCES_ASM:.S=.o) $(SOURCES_NASM:.asm=.o)
+DEPFLAGS     = -MMD -MP
 CXXFLAGS    += $(CPUOPTS) $(COREFLAGS) $(INCFLAGS) $(PLATCFLAGS) $(fpic) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
 CFLAGS      += $(CPUOPTS) $(COREFLAGS) $(INCFLAGS) $(PLATCFLAGS) $(fpic) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
 
@@ -693,6 +694,11 @@ else
 endif
 
 -include $(OBJECTS:.o=.d)
+# Pinned explicitly: the dependency include at the end of this file otherwise
+# displaces the default goal onto whichever object it mentions first, which
+# silently builds one .o and no library at all.
+.DEFAULT_GOAL := all
+
 all: $(TARGET)
 $(TARGET): $(OBJECTS)
 
@@ -714,13 +720,13 @@ $(AWK_DEST_DIR)/asm_defines_nasm.h: $(ASM_DEFINES_OBJ)
 	$(CC_AS) $(CFLAGS) -c $< -o $@
 
 %.o: %.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
 $(RSPDIR_PARALLEL)/lightning/lib/lightning.o: $(RSPDIR_PARALLEL)/lightning/lib/lightning.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) -DHAVE_MMAP=1 -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEPFLAGS) -DHAVE_MMAP=1 -c $< -o $@
 
 %.o: %.cpp
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
 clean:
 	find $(ROOT_DIR) -name "*.o" -type f -delete
@@ -728,3 +734,10 @@ clean:
 	rm -f $(TARGET)
 
 .PHONY: clean
+
+# Header dependency tracking, last in the file so it cannot affect the default
+# goal. Without it, editing a header rebuilds nothing that includes it and
+# objects end up compiled against different layouts of the same struct -- which
+# already cost a session a segfault that looked like a bad branch. `clean` was
+# always deleting *.d; only the flag was missing.
+-include $(OBJECTS:.o=.d)

--- a/custom/mupen64plus-next_common.h
+++ b/custom/mupen64plus-next_common.h
@@ -79,6 +79,10 @@ extern char* retro_dd_path_rom;
 extern char* retro_transferpak_rom_path;
 extern char* retro_transferpak_ram_path;
 
+/* Where the core may write a file the frontend did not name. Only the Game Boy
+ * cartridge save needs one; see get_gb_ram_path. */
+const char* retro_get_save_directory(void);
+
 // Threaded GL Callback
 extern void gln64_thr_gl_invoke_command_loop();
 extern bool threaded_gl_safe_shutdown;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -52,10 +52,14 @@
 #include "api/m64p_config.h"
 #include "osal_files.h"
 #include "main/rom.h"
+#include "device/dd/disk.h"
 #include "plugin/plugin.h"
 #include "device/rcp/pi/pi_controller.h"
 #include "device/pif/pif.h"
 #include "libretro_memory.h"
+
+#include <file/file_path.h>
+#include <string/stdstring.h>
 
 #include "audio_plugin.h"
 
@@ -157,6 +161,17 @@ int  retro_savestate_result = 0;
 // 64DD globals
 char* retro_dd_path_img = NULL;
 char* retro_dd_path_rom = NULL;
+
+/* Content is a bare 64DD disk booting from the IPL, with no cartridge. */
+static bool load_as_disk = false;
+
+static bool load_game_internal(const struct retro_game_info *game, bool is_disk);
+
+/* The core refuses ROM_CLOSE with no ROM open, leaving the disk open. */
+static void close_content(void)
+{
+    CoreDoCommand(load_as_disk ? M64CMD_DISK_CLOSE : M64CMD_ROM_CLOSE, 0, NULL);
+}
 
 // Other Subsystems
 char* retro_transferpak_rom_path = NULL;
@@ -365,8 +380,76 @@ static void setup_variables(void)
     environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
 }
 
+/* Mirrors is_valid_rom() in main/rom.c. */
+static bool content_is_n64_cart(const uint8_t* data, size_t size)
+{
+    uint32_t word;
+
+    if (data == NULL || size < 4)
+        return false;
+
+    word = load_beu32(data);
+
+    return (word == UINT32_C(0x80371240)   /* big endian    (.z64) */
+         || word == UINT32_C(0x37804012)   /* byte swapped  (.v64) */
+         || word == UINT32_C(0x40123780)); /* little endian (.n64) */
+}
+
+/* Carts are ruled out first, so a cart with a .ndd sidecar keeps its old path.
+ * No single positive test suffices: frontends rename content, game->path is
+ * NULL for archives, DD_REGION_DV is 0x00000000, and MAME dumps need not carry
+ * the region at word 0. */
+static bool content_is_dd_disk(const struct retro_game_info* game)
+{
+    const uint8_t* data;
+    size_t size;
+    uint32_t word;
+
+    if (game == NULL)
+        return false;
+
+    data = (const uint8_t*)game->data;
+    size = game->size;
+
+    if (content_is_n64_cart(data, size))
+        return false;
+
+    if (game->path && string_is_equal_noncase(path_get_extension(game->path), "ndd"))
+        return true;
+
+    if (size == MAME_FORMAT_DUMP_SIZE || size == SDK_FORMAT_DUMP_SIZE)
+        return true;
+
+    if (data != NULL && size >= 4)
+    {
+        word = load_beu32(data);
+
+        if (word == DD_REGION_JP || word == DD_REGION_US)
+            return true;
+
+        /* .v64 order: bytes swapped within each halfword */
+        word = ((uint32_t)m64p_swap16((unsigned short)(word >> 16)) << 16)
+             |  (uint32_t)m64p_swap16((unsigned short)(word & 0xffff));
+
+        if (word == DD_REGION_JP || word == DD_REGION_US)
+            return true;
+    }
+
+    return false;
+}
+
+/* open_disk() and load_dd_disk() ask the media loader for the disk filename;
+ * only the latter has its own fallback. Both free the returned string. */
+static char* media_loader_get_dd_disk(void* cb_data)
+{
+    (void)cb_data;
+    return retro_dd_path_img ? strdup(retro_dd_path_img) : NULL;
+}
+
 static void cleanup_global_paths()
 {
+    load_as_disk = false;
+
     // Ensure potential leftovers are cleaned up
     if(retro_dd_path_img)
     {
@@ -404,12 +487,18 @@ static void n64StateCallback(void *Context, m64p_core_param param_type, int new_
 
 static bool emu_step_load_data()
 {
-    log_cb(RETRO_LOG_DEBUG, CORE_NAME ": [EmuThread] M64CMD_ROM_OPEN\n");
+    /* DISK_OPEN takes no data; open_disk() reads the disk from its path. */
+    log_cb(RETRO_LOG_INFO, CORE_NAME ": [EmuThread] %s\n",
+           load_as_disk ? "M64CMD_DISK_OPEN (booting a 64DD disk, no cartridge)"
+                        : "M64CMD_ROM_OPEN (booting a cartridge)");
 
-    if(CoreDoCommand(M64CMD_ROM_OPEN, game_size, (void*)game_data))
+    if(CoreDoCommand(load_as_disk ? M64CMD_DISK_OPEN : M64CMD_ROM_OPEN,
+                     load_as_disk ? 0 : game_size,
+                     load_as_disk ? NULL : (void*)game_data))
     {
         if (log_cb)
-            log_cb(RETRO_LOG_ERROR, CORE_NAME ": failed to load ROM\n");
+            log_cb(RETRO_LOG_ERROR, CORE_NAME ": failed to load %s\n",
+                   load_as_disk ? "64DD disk" : "ROM");
         goto load_fail;
     }
 
@@ -418,6 +507,7 @@ static bool emu_step_load_data()
 
     log_cb(RETRO_LOG_DEBUG, CORE_NAME ": [EmuThread] M64CMD_ROM_GET_HEADER\n");
 
+    /* With no cartridge the core returns a zeroed header. */
     if(CoreDoCommand(M64CMD_ROM_GET_HEADER, sizeof(ROM_HEADER), &ROM_HEADER))
     {
         if (log_cb)
@@ -548,7 +638,19 @@ bool retro_load_game_special(unsigned game_type, const struct retro_game_info *i
         case RETRO_GAME_TYPE_DD:
             if(num_info == 1)
             {
+                /* info[] has one element; nothing below may touch info[1]. */
+                struct retro_game_info disk_info;
+
                 retro_dd_path_img = strdup(info[0].path);
+
+                log_cb(RETRO_LOG_INFO, "Loading 64DD disk %s (no cartridge)...\n", info[0].path);
+
+                memset(&disk_info, 0, sizeof(disk_info));
+                disk_info.path = info[0].path;
+
+                /* The frontend already told us this is a disk, so don't sniff. */
+                result = load_game_internal(&disk_info, true);
+                break;
             }
             else if(num_info == 2)
             {
@@ -557,9 +659,9 @@ bool retro_load_game_special(unsigned game_type, const struct retro_game_info *i
             } else {
                 return false;
             }
-            
+
             log_cb(RETRO_LOG_INFO, "Loading %s...\n", info[0].path);
-            
+
             result = load_file(info[1].path, &gameBuffer, &outSize) == file_ok;
             if(result)
             {
@@ -653,7 +755,7 @@ void retro_get_system_info(struct retro_system_info *info)
 {
     info->library_name = "Mupen64Plus-Next";
     info->library_version = "2.8" FLAVOUR_VERSION GIT_VERSION;
-    info->valid_extensions = "n64|v64|z64|bin|u1";
+    info->valid_extensions = "n64|v64|z64|bin|u1|ndd";
     info->need_fullpath = false;
     info->block_extract = false;
 }
@@ -726,6 +828,11 @@ void retro_init(void)
         game_thread = co_create(65536 * sizeof(void*) * 16, (void (*)(void))EmuThreadFunction);
     }
 
+    /* Only get_dd_disk: load_dd_rom() ignores get_dd_rom, and leaving
+     * get_gb_cart_rom/ram NULL keeps the transferpak fallback intact. */
+    memset(&g_media_loader, 0, sizeof(g_media_loader));
+    g_media_loader.get_dd_disk = media_loader_get_dd_disk;
+
     m64p_error ret = CoreStartup(FRONTEND_API_VERSION, ".", ".", NULL, n64DebugCallback, 0, n64StateCallback);
     if(ret && log_cb)
         log_cb(RETRO_LOG_ERROR, CORE_NAME ": failed to initialize core (err=%i)\n", ret);
@@ -740,7 +847,7 @@ void retro_deinit(void)
        {
            CoreDoCommand(M64CMD_STOP, 0, NULL);
            co_switch(game_thread); /* Let the core thread finish */
-           CoreDoCommand(M64CMD_ROM_CLOSE, 0, NULL);
+           close_content();
        }
     }
 
@@ -1878,14 +1985,37 @@ static bool retro_init_vulkan(void)
 
 bool retro_load_game(const struct retro_game_info *game)
 {
+    return load_game_internal(game, content_is_dd_disk(game));
+}
+
+/* is_disk is settled before the sidecar probe, so a disk is never handed its
+ * own name with a second ".ndd" appended. */
+static bool load_game_internal(const struct retro_game_info *game, bool is_disk)
+{
     char* gamePath;
     char* newPath;
+
+    load_as_disk = is_disk;
+
+    if(load_as_disk)
+    {
+        /* open_disk() and load_dd_disk() take a filename, not a buffer. */
+        if(!game->path)
+        {
+            if (log_cb)
+                log_cb(RETRO_LOG_ERROR, CORE_NAME ": 64DD disk images must be loaded from a real file path, not from an archive\n");
+            return false;
+        }
+
+        if(!retro_dd_path_img)
+            retro_dd_path_img = strdup(game->path);
+    }
 
     // Workaround for broken subsystem on static platforms
     // Note: game->path can be NULL if loading from a archive
     // Current impl. uses mupen internals so that wouldn't work either way for dd/tpak
     // So we just sanity check
-    if(!retro_dd_path_img && game->path)
+    if(!load_as_disk && !retro_dd_path_img && game->path)
     {
         gamePath = (char*)game->path;
         newPath = (char*)calloc(1, strlen(gamePath)+5);
@@ -1980,9 +2110,16 @@ bool retro_load_game(const struct retro_game_info *game)
     }
 #endif
 
-    game_data = malloc(game->size);
-    memcpy(game_data, game->data, game->size);
-    game_size = game->size;
+    /* Unused on the disk path; don't copy a whole disk image for nothing. */
+    game_data = NULL;
+    game_size = 0;
+
+    if (!load_as_disk)
+    {
+        game_data = malloc(game->size);
+        memcpy(game_data, game->data, game->size);
+        game_size = game->size;
+    }
 
     if (!emu_step_load_data())
         return false;
@@ -2028,7 +2165,7 @@ void retro_unload_game(void)
 
        environ_clear_thread_waits_cb(0, NULL);
 
-       CoreDoCommand(M64CMD_ROM_CLOSE, 0, NULL);
+       close_content();
     }
 
     cleanup_global_paths();

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -29,6 +29,7 @@
 
 #include "GLideN64_libretro.h"
 #include "mupen64plus-next_common.h"
+#include "transferpak_interface.h"
 
 #include <libco.h>
 
@@ -176,6 +177,13 @@ static void close_content(void)
 // Other Subsystems
 char* retro_transferpak_rom_path = NULL;
 char* retro_transferpak_ram_path = NULL;
+
+/* Per-port Transfer Pak media, when the frontend answers for it. The two paths
+ * above are ONE cartridge shared by every port and fixed at load; these are four
+ * independent paks whose cartridges can be changed while the game runs. */
+static struct retro_transfer_pak_interface transferpak_iface;
+static bool transferpak_iface_ok = false;
+static unsigned transferpak_generation[RETRO_TRANSFER_PAK_PORTS] = {0};
 
 uint32_t CoreOptionCategoriesSupported = 0;
 uint32_t CoreOptionUpdateDisplayCbSupported = 0;
@@ -446,6 +454,58 @@ static char* media_loader_get_dd_disk(void* cb_data)
     return retro_dd_path_img ? strdup(retro_dd_path_img) : NULL;
 }
 
+/* The frontend owns the string it hands back and may reuse the buffer, while
+ * main.c takes ownership of what these return: open_rom_file_storage keeps it
+ * and close_file_storage frees it, and the no-cart path frees it directly. So
+ * every answer is copied, and an empty answer becomes NULL rather than a "" that
+ * would later be free()d as a string literal. */
+static char* media_loader_get_gb_cart_rom(void* cb_data, int controller_num)
+{
+    const char* path;
+    (void)cb_data;
+    if (!transferpak_iface_ok || !transferpak_iface.get_rom)
+        return NULL;
+    if (controller_num < 0 || controller_num >= RETRO_TRANSFER_PAK_PORTS)
+        return NULL;
+    path = transferpak_iface.get_rom(transferpak_iface.frontend_data, (unsigned)controller_num);
+    return (path && *path) ? strdup(path) : NULL;
+}
+
+static char* media_loader_get_gb_cart_ram(void* cb_data, int controller_num)
+{
+    const char* path;
+    (void)cb_data;
+    if (!transferpak_iface_ok || !transferpak_iface.get_ram)
+        return NULL;
+    if (controller_num < 0 || controller_num >= RETRO_TRANSFER_PAK_PORTS)
+        return NULL;
+    path = transferpak_iface.get_ram(transferpak_iface.frontend_data, (unsigned)controller_num);
+    return (path && *path) ? strdup(path) : NULL;
+}
+
+/* Re-read a port's cartridge when the frontend says it changed under a pak that
+ * never left the controller.
+ *
+ * main_change_gb_cart only runs off a pak-TYPE transition, so without this a
+ * cartridge swapped in place is never noticed. Rather than add a second state
+ * machine, this raises the flag the existing delayed eject/insert path already
+ * watches, so a swap takes the same two delays a pak change does. */
+static void transferpak_poll_generation(void)
+{
+    int i;
+    if (!transferpak_iface_ok || !transferpak_iface.generation)
+        return;
+    for (i = 0; i < RETRO_TRANSFER_PAK_PORTS; ++i)
+    {
+        unsigned gen = transferpak_iface.generation(transferpak_iface.frontend_data, (unsigned)i);
+        if (gen == transferpak_generation[i])
+            continue;
+        transferpak_generation[i] = gen;
+        if (Controls[i].Plugin == PLUGIN_TRANSFER_PAK)
+            main_request_gb_cart_switch(i);
+    }
+}
+
 static void cleanup_global_paths()
 {
     load_as_disk = false;
@@ -614,6 +674,20 @@ const char* retro_get_system_directory(void)
 {
     const char* dir;
     environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir);
+
+    return dir ? dir : ".";
+}
+
+/* Where the core may write a file the frontend did not name for it.
+ *
+ * Only the Game Boy cartridge save uses this: every other save in this core goes
+ * through saved_memory, which the frontend persists itself. A frontend that
+ * refuses the call gets the working directory, which is what the system
+ * directory helper above already falls back to. */
+const char* retro_get_save_directory(void)
+{
+    const char* dir = NULL;
+    environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir);
 
     return dir ? dir : ".";
 }
@@ -828,10 +902,27 @@ void retro_init(void)
         game_thread = co_create(65536 * sizeof(void*) * 16, (void (*)(void))EmuThreadFunction);
     }
 
-    /* Only get_dd_disk: load_dd_rom() ignores get_dd_rom, and leaving
-     * get_gb_cart_rom/ram NULL keeps the transferpak fallback intact. */
+    /* load_dd_rom() ignores get_dd_rom, so only get_dd_disk is wired for the
+     * disk drive. */
     memset(&g_media_loader, 0, sizeof(g_media_loader));
     g_media_loader.get_dd_disk = media_loader_get_dd_disk;
+
+    /* The GB cart hooks go in ONLY when a frontend answers for them. Left NULL
+     * the core falls back to retro_transferpak_{rom,ram}_path — one cartridge
+     * shared by every port, from the `gb` subsystem or the <rom>.gb sidecar —
+     * which is what every existing frontend expects and must keep getting. */
+    memset(&transferpak_iface, 0, sizeof(transferpak_iface));
+    memset(transferpak_generation, 0, sizeof(transferpak_generation));
+    transferpak_iface_ok =
+        environ_cb(RETRO_ENVIRONMENT_GET_TRANSFER_PAK_INTERFACE, &transferpak_iface)
+        || environ_cb(RETRO_ENVIRONMENT_GET_TRANSFER_PAK_INTERFACE_FINAL, &transferpak_iface);
+    if (transferpak_iface_ok)
+    {
+        g_media_loader.get_gb_cart_rom = media_loader_get_gb_cart_rom;
+        g_media_loader.get_gb_cart_ram = media_loader_get_gb_cart_ram;
+        if (log_cb)
+            log_cb(RETRO_LOG_INFO, CORE_NAME ": frontend serves Transfer Pak media per port\n");
+    }
 
     m64p_error ret = CoreStartup(FRONTEND_API_VERSION, ".", ".", NULL, n64DebugCallback, 0, n64StateCallback);
     if(ret && log_cb)
@@ -1878,6 +1969,10 @@ static void update_variables(bool startup)
 #endif // HAVE_THR_AL
 
     update_controllers();
+    /* After update_controllers, so a port that has only just become a Transfer
+     * Pak is seen as one. A cartridge changed under a pak that never left the
+     * controller is invisible to the pak-type transition above. */
+    transferpak_poll_generation();
 
     // Hide irrelevant options
     set_variable_visibility();

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -268,6 +268,23 @@ static void n64DebugCallback(void* aContext, int aLevel, const char* aMessage)
     snprintf(buffer, 1024, CORE_NAME ": %s\n", aMessage);
     if (log_cb)
         log_cb(RETRO_LOG_INFO, buffer);
+
+    /* Everything the core has to say arrives here at RETRO_LOG_INFO, which
+     * frontends routinely drop -- so the warnings that matter when something is
+     * wrong (out-of-bound reads, unknown devices, unimplemented paths) are
+     * invisible, and diagnosing anything meant rebuilding with fprintf added by
+     * hand. Mirror to stderr when M64P_VERBOSE is set; opt-in, so normal runs
+     * stay quiet. */
+    {
+        static int verbose = -1;
+        if (verbose < 0)
+            verbose = (getenv("M64P_VERBOSE") != NULL) ? 1 : 0;
+        if (verbose)
+        {
+            fprintf(stderr, "[m64p:%d] %s", aLevel, buffer);
+            fflush(stderr);
+        }
+    }
 }
 
 extern m64p_rom_header ROM_HEADER;

--- a/libretro/transferpak_interface.h
+++ b/libretro/transferpak_interface.h
@@ -1,0 +1,67 @@
+/* Transfer Pak media interface — how a frontend says which Game Boy cartridge
+ * is in which controller's Transfer Pak.
+ *
+ * mupen64plus-core already resolves the cartridge PER CONTROLLER: init_gb_rom
+ * and init_gb_ram are handed a control_id and ask g_media_loader for that port's
+ * files. What the libretro layer has never had is a way for the frontend to
+ * answer per port — the two routes that exist, the `gb` subsystem and the
+ * <rom>.gb sidecar, both set one pair of globals shared by all four ports and
+ * both are fixed at load. One cartridge, in every pak, for the whole session.
+ *
+ * This is the missing half: the core ASKS, at the moment a pak is populated,
+ * naming the port. Modelled on the frontend-supplied interfaces libretro already
+ * has (rumble, sensors, led), and on RETRO_ENVIRONMENT_GET_LINK_INTERFACE, which
+ * this project reserves the same way.
+ *
+ * A frontend that does not answer leaves the core exactly as it was: the media
+ * loader hooks stay NULL and the global/sidecar fallback still applies, so a
+ * RetroArch user sees no change at all.
+ *
+ * The number is provisional. Take the EXPERIMENTAL form first and fall back to
+ * the plain one, so a core built today keeps working against a frontend that
+ * later adopts the unflagged number.
+ */
+
+#ifndef TRANSFERPAK_INTERFACE_H
+#define TRANSFERPAK_INTERFACE_H
+
+#include <libretro.h>
+
+#define RETRO_ENVIRONMENT_GET_TRANSFER_PAK_INTERFACE       (95 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+#define RETRO_ENVIRONMENT_GET_TRANSFER_PAK_INTERFACE_FINAL 95
+
+/* How many controllers may hold a pak. Matches GAME_CONTROLLERS_COUNT; declared
+ * here too so the frontend side of this contract does not have to include the
+ * core's headers to know the range of `port`. */
+#define RETRO_TRANSFER_PAK_PORTS 4
+
+struct retro_transfer_pak_interface
+{
+   /* Passed back to every call below. */
+   void *frontend_data;
+
+   /* The Game Boy ROM in the Transfer Pak on `port` (0-3), or NULL/"" for a pak
+    * with no cartridge in it — or for a port with no Transfer Pak at all.
+    *
+    * The string is owned by the FRONTEND and must stay valid until the next call
+    * on the same port; the core copies it before use. */
+   const char *(*get_rom)(void *frontend_data, unsigned port);
+
+   /* Where that cartridge's battery save lives. Same ownership as get_rom.
+    *
+    * NULL or "" leaves the core to name a file itself, which on this core means
+    * the save is silently discarded — get_gb_ram_path is stubbed to "". A
+    * frontend that wants the save kept must answer this. */
+   const char *(*get_ram)(void *frontend_data, unsigned port);
+
+   /* A counter the frontend bumps whenever the CARTRIDGE in `port`'s pak changes
+    * without the pak itself being removed.
+    *
+    * Needed because the core only re-reads a cartridge when the pak TYPE
+    * transitions, so swapping one cartridge for another while the pak stays
+    * seated would otherwise go unnoticed for the rest of the session. May be
+    * NULL, in which case only a pak change re-reads. */
+   unsigned (*generation)(void *frontend_data, unsigned port);
+};
+
+#endif

--- a/mupen64plus-core/src/device/dd/disk.c
+++ b/mupen64plus-core/src/device/dd/disk.c
@@ -405,7 +405,7 @@ uint8_t* scan_and_expand_disk_format(uint8_t* data, size_t size,
 {
     /* Search for good System Data */
     const unsigned int blocks[8] = { 0, 1, 2, 3, 8, 9, 10, 11 };
-    int isValidDisk = -1;
+    int sys_data_block = -1;
     int isValidDiskID = -1;
     unsigned int isDevelopment = 0;
 
@@ -416,7 +416,7 @@ uint8_t* scan_and_expand_disk_format(uint8_t* data, size_t size,
 
         if ((offset + 0x20) >= size || (size < MAME_FORMAT_DUMP_SIZE && size < SDK_FORMAT_DUMP_SIZE && i > 0))
         {
-            isValidDisk = -1;
+            sys_data_block = -1;
             break;
         }
 
@@ -438,7 +438,7 @@ uint8_t* scan_and_expand_disk_format(uint8_t* data, size_t size,
         case DD_REGION_JP:
         case DD_REGION_US:
         case DD_REGION_DV:
-            isValidDisk = i;
+            sys_data_block = blocks[i];
             break;
         default:
             continue;
@@ -457,24 +457,24 @@ uint8_t* scan_and_expand_disk_format(uint8_t* data, size_t size,
             {
                 if (memcmp(&data[offset + ((j - 1) * sectorsize)], &data[offset + (j * sectorsize)], sectorsize) != 0)
                 {
-                    isValidDisk = -1;
+                    sys_data_block = -1;
                     break;
                 }
                 else
                 {
-                    isValidDisk = i;
+                    sys_data_block = blocks[i];
                 }
             }
         }
 
-        if (isValidDisk != -1)
+        if (sys_data_block != -1)
             break;
     }
 
-    if (isValidDisk == 2 || isValidDisk == 3 || isValidDisk == 10 || isValidDisk == 11)
+    if (sys_data_block == 2 || sys_data_block == 3 || sys_data_block == 10 || sys_data_block == 11)
         isDevelopment = 1;
 
-    if (isValidDisk == -1)
+    if (sys_data_block == -1)
     {
         DebugMessage(M64MSG_ERROR, "Invalid DD Disk System Data.");
         return NULL;
@@ -534,12 +534,12 @@ uint8_t* scan_and_expand_disk_format(uint8_t* data, size_t size,
 
         if (ram_lba_start != (RAM_START_LBA[disk_type] - 24) && ram_lba_start != 0xFFFF)
         {
-            isValidDisk = -1;
+            sys_data_block = -1;
             DebugMessage(M64MSG_ERROR, "Invalid D64 Disk RAM Start Info (expected %04X)", (RAM_START_LBA[disk_type] - SYSTEM_LBAS));
         }
         else if (size != d64_size)
         {
-            isValidDisk = -1;
+            sys_data_block = -1;
             DebugMessage(M64MSG_ERROR, "Invalid D64 Disk size %zu (calculated 0x200 + 0x%zx + 0x%zx = %zu).", size, rom_size, ram_size, d64_size);
         }
         else
@@ -582,14 +582,14 @@ uint8_t* scan_and_expand_disk_format(uint8_t* data, size_t size,
     case MAME_FORMAT_DUMP_SIZE:
         *format = DISK_FORMAT_MAME;
         *development = isDevelopment;
-        *offset_sys = 0x4D08 * isValidDisk;
+        *offset_sys = 0x4D08 * sys_data_block;
         *offset_id = 0x4D08 * isValidDiskID;
         break;
 
     case SDK_FORMAT_DUMP_SIZE: {
         *format = DISK_FORMAT_SDK;
         *development = isDevelopment;
-        *offset_sys = 0x4D08 * isValidDisk;
+        *offset_sys = 0x4D08 * sys_data_block;
         *offset_id = 0x4D08 * isValidDiskID;
         const struct dd_sys_data* sys_data = (void*)(&data[*offset_sys]);
         *offset_ram = LBAToByteA(sys_data->type & 0xF, 0, RAM_START_LBA[sys_data->type & 0xF]);
@@ -597,7 +597,7 @@ uint8_t* scan_and_expand_disk_format(uint8_t* data, size_t size,
         } break;
 
     default:
-        if (isValidDisk == -1)
+        if (sys_data_block == -1)
         {
             DebugMessage(M64MSG_ERROR, "Invalid DD Disk size %zu.", size);
             return NULL;

--- a/mupen64plus-core/src/device/device.c
+++ b/mupen64plus-core/src/device/device.c
@@ -247,6 +247,12 @@ void init_device(struct device* dev,
 #define W(x) write_ ## x
 #define RW(x) R(x), W(x)
 #define A(x,m) (x), (x) | (m)
+    /* Indices patched below. Keep in sync with mappings[]. */
+    enum {
+        MAPPING_DOM2_ADDR1 = 14,
+        MAPPING_DD_ROM     = 15,
+        MAPPING_CART_ROM   = 18
+    };
     struct mem_mapping mappings[] = {
         /* clear mappings */
         { 0x00000000, 0xffffffff, M64P_MEM_NOTHING, { NULL, RW(open_bus) }, { NULL, 0, 0 } },
@@ -268,14 +274,20 @@ void init_device(struct device* dev,
         { A(MM_DD_ROM, 0x1ffffff), M64P_MEM_NOTHING, { NULL, RW(open_bus) }, { NULL, 0x1ffffff, 0 } },
         { A(MM_DOM2_ADDR2, 0x1ffff), M64P_MEM_FLASHRAMSTAT, { &dev->cart, RW(cart_dom2) }, { NULL, 0x1ffff, 0} },
         { A(MM_IS_VIEWER, 0xfff), M64P_MEM_NOTHING, { &dev->is, RW(is_viewer) }, { NULL, 0xfff, 0 } },
-        { A(MM_CART_ROM, rom_size-1), M64P_MEM_ROM, { &dev->cart.cart_rom, RW(cart_rom) }, { NULL, rom_size-1, RETRO_MEMDESC_CONST } },
+        { A(MM_CART_ROM, 0xfffffff), M64P_MEM_NOTHING, { NULL, RW(open_bus) }, { NULL, 0xfffffff, 0 } },
         { A(MM_PIF_MEM, 0xffff), M64P_MEM_PIF, { &dev->pif, RW(pif_mem) }, { NULL, 0xffff, 0 } }
     };
 
+    /* init and map CART ROM if present. With no cartridge rom_size-1 would
+     * underflow to SIZE_MAX, so the table leaves it as open bus. */
+    if (rom_size > 0) {
+        mappings[MAPPING_CART_ROM] = (struct mem_mapping){ A(MM_CART_ROM, rom_size-1), M64P_MEM_ROM, { &dev->cart.cart_rom, RW(cart_rom) }, { NULL, rom_size-1, RETRO_MEMDESC_CONST } };
+    }
+
     /* init and map DD if present */
     if (dd_rom_size > 0) {
-        mappings[14] = (struct mem_mapping){ A(MM_DOM2_ADDR1, 0xffffff), M64P_MEM_DDREG, { &dev->dd, RW(dd_regs) }, { NULL, 0xffffff, 0 } };
-        mappings[15] = (struct mem_mapping){ A(MM_DD_ROM, dd_rom_size-1), M64P_MEM_DDROM, { &dev->dd, RW(dd_rom) }, { NULL, dd_rom_size-1, RETRO_MEMDESC_CONST } };
+        mappings[MAPPING_DOM2_ADDR1] = (struct mem_mapping){ A(MM_DOM2_ADDR1, 0xffffff), M64P_MEM_DDREG, { &dev->dd, RW(dd_regs) }, { NULL, 0xffffff, 0 } };
+        mappings[MAPPING_DD_ROM] = (struct mem_mapping){ A(MM_DD_ROM, dd_rom_size-1), M64P_MEM_DDROM, { &dev->dd, RW(dd_rom) }, { NULL, dd_rom_size-1, RETRO_MEMDESC_CONST } };
 
         init_dd(&dev->dd,
                 dd_rtc_clock, dd_rtc_iclock,

--- a/mupen64plus-core/src/device/gb/gb_cart.c
+++ b/mupen64plus-core/src/device/gb/gb_cart.c
@@ -54,7 +54,14 @@ enum gbcart_extra_devices
 /* various helper functions for ram, rom, or MBC uses */
 
 
-static void read_rom(const void* rom_storage, const struct storage_backend_interface* irom_storage, uint16_t address, uint8_t* data, size_t size)
+/* `address` is a ROM OFFSET, not a Game Boy address: every caller passes
+ * (address - 0x4000) + rom_bank * 0x4000, which for bank 4 is already 0x10000.
+ * Declared uint16_t it wrapped, so a 1 MB cartridge read banks 0-3 correctly
+ * and returned bank & 3 for everything above -- the header checksummed, the
+ * whole ROM streamed, and the game rejected the cart at the end because its
+ * global checksum could not match. Pokemon Stadium reports that as "The
+ * Transfer Pak is not set properly". */
+static void read_rom(const void* rom_storage, const struct storage_backend_interface* irom_storage, uint32_t address, uint8_t* data, size_t size)
 {
     assert(size > 0);
 

--- a/mupen64plus-core/src/main/main.c
+++ b/mupen64plus-core/src/main/main.c
@@ -147,6 +147,12 @@ static void* l_paks[GAME_CONTROLLERS_COUNT][PAK_MAX_SIZE];
 static const struct pak_interface* l_ipaks[PAK_MAX_SIZE];
 static size_t l_pak_type_idx[6];
 
+/* Moved out of main_run's frame so the libretro layer can raise a port's GB cart
+ * switch from outside the emulation loop. It was a local, and a pointer to a
+ * local would dangle the moment main_run returned; there is one core per process
+ * here, so file scope costs nothing. */
+static struct controller_input_compat l_cin_compats[GAME_CONTROLLERS_COUNT];
+
 /* PRNG state - used for Mempaks ID generation */
 struct xoshiro256pp_state l_mpk_idgen;
 
@@ -203,9 +209,25 @@ static char *get_flashram_path(void)
     return "";
 }
 
+/* A default file for a Game Boy cartridge's battery save, when the frontend did
+ * not name one.
+ *
+ * This returned "" like every other path helper here, and unlike them that was
+ * not harmless. The rest of this core's saves live in saved_memory, which the
+ * frontend persists itself, so their stubs are never reached for anything real.
+ * A GB cartridge's save is the one thing the core writes to a FILE of its own:
+ * with an empty name every write failed silently, so a Transfer Pak game's save
+ * was simply discarded -- and close_file_storage then called free() on a string
+ * literal when the cartridge was ejected.
+ *
+ * Composed against the frontend's save directory rather than get_savesrampath(),
+ * which is itself one of the stubs. */
 static char *get_gb_ram_path(const char* gbrom, unsigned int control_id)
 {
-    return "";
+    const char* dir = retro_get_save_directory();
+    size_t len = strlen(dir);
+    const char* sep = (len > 0 && (dir[len - 1] == '/' || dir[len - 1] == '\\')) ? "" : "/";
+    return formatstr("%s%s%s.%u.sav", dir, sep, gbrom, control_id);
 }
 
 const char *get_savestatepath(void)
@@ -1319,6 +1341,21 @@ static void release_gb_ram(void* opaque)
     memset(&data->ram_fstorage, 0, sizeof(data->ram_fstorage));
 }
 
+/* Ask for a port's Game Boy cartridge to be read again.
+ *
+ * For a cartridge swapped while the Transfer Pak itself stayed in the
+ * controller: main_change_gb_cart only ever runs off a pak-TYPE transition, so
+ * without this the core keeps serving the cartridge it first saw for the rest of
+ * the session. Raising the flag rather than reloading here on the spot means the
+ * swap goes through the same delayed eject/insert the pak change does, and the
+ * game sees the cartridge leave before it sees another arrive. */
+void main_request_gb_cart_switch(int control_id)
+{
+    if (control_id < 0 || control_id >= GAME_CONTROLLERS_COUNT)
+        return;
+    l_cin_compats[control_id].gb_cart_switch_enabled = 1;
+}
+
 void main_change_gb_cart(int control_id)
 {
     struct transferpak* tpk = &g_dev.transferpaks[control_id];
@@ -1382,7 +1419,6 @@ m64p_error main_run(void)
     struct audio_out_backend_interface audio_out_backend_libretro;
 
     int control_ids[GAME_CONTROLLERS_COUNT];
-    struct controller_input_compat cin_compats[GAME_CONTROLLERS_COUNT];
 
     struct file_storage mpk_storages[GAME_CONTROLLERS_COUNT];
     struct file_storage mpk;
@@ -1522,9 +1558,9 @@ m64p_error main_run(void)
 
     memset(&g_dev.gb_carts, 0, GAME_CONTROLLERS_COUNT*sizeof(*g_dev.gb_carts));
     memset(&l_gb_carts_data, 0, GAME_CONTROLLERS_COUNT*sizeof(*l_gb_carts_data));
-    memset(cin_compats, 0, GAME_CONTROLLERS_COUNT*sizeof(*cin_compats));
+    memset(l_cin_compats, 0, GAME_CONTROLLERS_COUNT*sizeof(*l_cin_compats));
 
-    netplay_read_registration(cin_compats);
+    netplay_read_registration(l_cin_compats);
 
     for (i = 0; i < GAME_CONTROLLERS_COUNT; ++i) {
 
@@ -1543,19 +1579,19 @@ m64p_error main_run(void)
             joybus_devices[i] = &g_dev.controllers[i];
             ijoybus_devices[i] = &g_ijoybus_vru_controller;
 
-            cin_compats[i].control_id = (int)i;
-            cin_compats[i].cont = &g_dev.controllers[i];
-            cin_compats[i].last_pak_type = Controls[i].Plugin;
-            cin_compats[i].last_input = 0;
-            cin_compats[i].netplay_count = 0;
-            cin_compats[i].event_first = NULL;
+            l_cin_compats[i].control_id = (int)i;
+            l_cin_compats[i].cont = &g_dev.controllers[i];
+            l_cin_compats[i].last_pak_type = Controls[i].Plugin;
+            l_cin_compats[i].last_input = 0;
+            l_cin_compats[i].netplay_count = 0;
+            l_cin_compats[i].event_first = NULL;
 
             Controls[i].Plugin = PLUGIN_NONE;
 
             /* init vru_controller */
             init_game_controller(&g_dev.controllers[i],
                     cont_flavor,
-                    &cin_compats[i], &g_icontroller_input_backend_plugin_compat,
+                    &l_cin_compats[i], &g_icontroller_input_backend_plugin_compat,
                     NULL, NULL);
         }
         /* otherwise let the core do the processing */
@@ -1570,13 +1606,13 @@ m64p_error main_run(void)
             joybus_devices[i] = &g_dev.controllers[i];
             ijoybus_devices[i] = &g_ijoybus_device_controller;
 
-            cin_compats[i].control_id = (int)i;
-            cin_compats[i].cont = &g_dev.controllers[i];
-            cin_compats[i].tpk = &g_dev.transferpaks[i];
-            cin_compats[i].last_pak_type = Controls[i].Plugin;
-            cin_compats[i].last_input = 0;
-            cin_compats[i].netplay_count = 0;
-            cin_compats[i].event_first = NULL;
+            l_cin_compats[i].control_id = (int)i;
+            l_cin_compats[i].cont = &g_dev.controllers[i];
+            l_cin_compats[i].tpk = &g_dev.transferpaks[i];
+            l_cin_compats[i].last_pak_type = Controls[i].Plugin;
+            l_cin_compats[i].last_input = 0;
+            l_cin_compats[i].netplay_count = 0;
+            l_cin_compats[i].event_first = NULL;
 
             l_gb_carts_data[i].control_id = (int)i;
 
@@ -1643,7 +1679,7 @@ m64p_error main_run(void)
                     }
 
                     /* enable GB cart switch */
-                    // cin_compats[i].gb_cart_switch_enabled = 1;
+                    // l_cin_compats[i].gb_cart_switch_enabled = 1;
                 }
                 /* No Pak */
                 else {
@@ -1661,7 +1697,7 @@ m64p_error main_run(void)
             /* init game_controller */
             init_game_controller(&g_dev.controllers[i],
                     cont_flavor,
-                    &cin_compats[i], &g_icontroller_input_backend_plugin_compat,
+                    &l_cin_compats[i], &g_icontroller_input_backend_plugin_compat,
                     l_paks[i][l_paks_idx[i]], l_ipaks[l_paks_idx[i]]);
 
             if (l_ipaks[l_paks_idx[i]] != NULL) {

--- a/mupen64plus-core/src/main/main.h
+++ b/mupen64plus-core/src/main/main.h
@@ -65,6 +65,7 @@ void new_vi(void);
 void main_switch_next_pak(int control_id);
 void main_switch_plugin_pak(int control_id);
 void main_change_gb_cart(int control_id);
+void main_request_gb_cart_switch(int control_id);
 
 int  main_set_core_defaults(void);
 void main_message(m64p_msg_level level, unsigned int osd_corner, const char *format, ...) ATTR_FMT(3, 4);


### PR DESCRIPTION
The core has long been able to boot a 64DD disk with no cartridge, but none of it was reachable: emu_step_load_data() always issued M64CMD_ROM_OPEN, so a disk was rejected by is_valid_rom() and M64CMD_DISK_OPEN was never sent.

 - Detect a disk in retro_load_game(), by .ndd extension, the two canonical dump sizes, or the JP/US region word in either endianness. Carts are ruled out first, so any cartridge takes the path it took before.

 - Supply g_media_loader.get_dd_disk. Nothing populated it, so open_disk() could never find a disk.

 - Send M64CMD_DISK_CLOSE, not M64CMD_ROM_CLOSE, when a disk is open. The core rejects ROM_CLOSE with no ROM open, failing the next load.

 - Skip the content copy on the disk path, since DISK_OPEN takes no data.

 - Add ndd to valid_extensions. need_fullpath stays false; changing it would break in-memory and archived cartridge loading.

Also fixes an out-of-bounds read: the num_info == 1 branch of RETRO_GAME_TYPE_DD fell through to info[1] on a one-element array.

Two core changes come with it. Only the first is required:

device.c: with no cartridge rom_size is 0 and rom_size-1 underflows to SIZE_MAX. The resulting mapping end is harmless and matches upstream, but setup_retroarch_memory_map() exports the entry unconditionally, handing the frontend a descriptor with a NULL pointer and a SIZE_MAX length.

dd/disk.c: an unrelated bug, not needed to boot a disk. scan_and_expand_disk_format() stored the loop index where both uses want the block number, so system data found in block 8-11 yields an offset pointing at block 4-7. It fails silently, returning the wrong region. The development test had the same confusion: 2 and 3 match by coincidence, while 10 and 11 never match an index running 0-7. Every intact dump keeps four copies, at blocks 0,1,8,9 or 2,3,10,11, and the scan takes the first, so this is only reachable once blocks 0-3 are unreadable. 15 disks checked, none affected.