### PR TITLE
libretro: advertise serialization initialization requirement

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -705,6 +705,8 @@ void retro_init(void)
 
     struct retro_log_callback log;
     unsigned colorMode = RETRO_PIXEL_FORMAT_XRGB8888;
+    uint64_t serialization_quirks =
+        RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE;
 
     if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log))
         log_cb = log.log;
@@ -717,6 +719,8 @@ void retro_init(void)
         perf_get_cpu_features_cb = NULL;
 
     environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &colorMode);
+    environ_cb(RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS,
+          &serialization_quirks);
     environ_cb(RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumble);
     if(!(current_rdp_type == RDP_PLUGIN_GLIDEN64 && EnableThreadedRenderer))
     {


### PR DESCRIPTION
## Summary

Advertise `RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE` to the libretro frontend.

This tells the frontend that save-state serialization/unserialization is not safe until the core has completed its initialization.

## Problem

Mupen64Plus-Next can reject `retro_unserialize()` while the core is still initializing.

When RetroArch's State Auto Load feature attempts to restore a state immediately during content startup, the request can therefore arrive too early and fail. Loading the same state manually after the game has started works normally.

## Solution

Advertise the existing libretro `RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE` serialization quirk from the core.

This does not change the core's existing save-state implementation or initialization guards. It simply exposes the initialization requirement to frontends that support this quirk.

Frontends that do not handle this quirk can continue loading the core normally; the environment callback is not treated as a hard dependency.

## Testing

Tested with an Android arm64-v8a GLES3 build together with the companion RetroArch change.

Using GLideN64/OpenGL:

- State Auto Save successfully created the automatic state.
- Relaunching the same content automatically restored the saved state.
- No manual Load State action was required.
- Core startup and gameplay remained stable.

## Related

- #560
- Companion RetroArch PR: https://github.com/libretro/RetroArch/pull/19487